### PR TITLE
fix(ci): quality-gates fails to compile (or → ||)

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -646,7 +646,7 @@ jobs:
         performance_compliant = "${{ needs.performance-standards.outputs.performance-compliant }}" == "true"
 
         # Set compliance level thresholds
-        compliance_level = "${{ github.event.inputs.compliance_level or 'enterprise' }}"
+        compliance_level = "${{ github.event.inputs.compliance_level || 'enterprise' }}"
 
         thresholds = {
             'basic': {'quality': 70, 'security': 70, 'complexity': 60},


### PR DESCRIPTION
## Problem
`quality-gates.yml` has failed to **compile** since 2026-01-28, so GitHub records a startup-failure run (0 jobs, no logs) on every push and **none of its quality checks have actually run** for months.

Root cause — line 649 uses `or`, which isn't a valid GitHub Actions expression operator (only `||`/`&&` exist):

```yaml
compliance_level = "${{ github.event.inputs.compliance_level or 'enterprise' }}"
```

## Fix
`or` → `||`. Verified with `actionlint`: the `[expression]` compile error is gone (only pre-existing `set-output` deprecation warnings remain, which are non-fatal and left for a separate cleanup).

## Heads-up
This makes the workflow compile and **run for the first time in months** (on PRs + the weekly schedule). Dormant jobs — coverage thresholds, `clippy -D warnings`, license/compliance — may now surface **real** failures that were previously masked by the startup error. That's expected; this PR restores the gate's functionality, it doesn't guarantee the checks pass.