### PR TITLE
fix(ci): green the Linting + Windows test jobs (fmt, clippy 1.96, cross-platform tests)

### DIFF
--- a/src/batch/queue.rs
+++ b/src/batch/queue.rs
@@ -909,7 +909,7 @@ impl JobQueueManager {
         }
 
         // Sort by creation time (newest first)
-        job_infos.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        job_infos.sort_by_key(|b| std::cmp::Reverse(b.created_at));
 
         Ok(job_infos)
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -683,7 +683,7 @@ impl ModelCache {
         // Get all available models and sort by size
         if let Ok(models) = self.model_manager.list_models().await {
             let mut sorted_models = models;
-            sorted_models.sort_by(|a, b| a.size.cmp(&b.size));
+            sorted_models.sort_by_key(|a| a.size);
 
             // Warm up smaller models first
             for model in sorted_models.iter().take(3) {

--- a/src/cli/audit.rs
+++ b/src/cli/audit.rs
@@ -1439,20 +1439,20 @@ mod tests {
 
     #[test]
     fn test_validate_export_params_zero_limit() {
-        let result = validate_export_params(&PathBuf::from("/tmp/test.json"), Some(0));
+        let result = validate_export_params(&std::env::temp_dir().join("test.json"), Some(0));
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("at least 1"));
     }
 
     #[test]
     fn test_validate_export_params_valid() {
-        let result = validate_export_params(&PathBuf::from("/tmp/test.json"), Some(100));
+        let result = validate_export_params(&std::env::temp_dir().join("test.json"), Some(100));
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_validate_export_params_no_limit() {
-        let result = validate_export_params(&PathBuf::from("/tmp/test.json"), None);
+        let result = validate_export_params(&std::env::temp_dir().join("test.json"), None);
         assert!(result.is_ok());
     }
 

--- a/src/cli/audit.rs
+++ b/src/cli/audit.rs
@@ -482,7 +482,7 @@ fn count_by_event_type(events: &[AuditEvent]) -> Vec<(String, usize)> {
         *counts.entry(key).or_insert(0) += 1;
     }
     let mut result: Vec<_> = counts.into_iter().collect();
-    result.sort_by(|a, b| b.1.cmp(&a.1));
+    result.sort_by_key(|b| std::cmp::Reverse(b.1));
     result
 }
 
@@ -494,7 +494,7 @@ fn count_by_severity(events: &[AuditEvent]) -> Vec<(String, usize)> {
         *counts.entry(key).or_insert(0) += 1;
     }
     let mut result: Vec<_> = counts.into_iter().collect();
-    result.sort_by(|a, b| b.1.cmp(&a.1));
+    result.sort_by_key(|b| std::cmp::Reverse(b.1));
     result
 }
 

--- a/src/cli/bench.rs
+++ b/src/cli/bench.rs
@@ -30,7 +30,11 @@ pub struct BenchArgs {
     #[arg(long, help = "Enable detailed per-iteration output")]
     pub verbose: bool,
 
-    #[arg(long, value_name = "FILE", help = "Write results to JSON file for comparison tracking")]
+    #[arg(
+        long,
+        value_name = "FILE",
+        help = "Write results to JSON file for comparison tracking"
+    )]
     pub output_json: Option<PathBuf>,
 }
 
@@ -264,10 +268,7 @@ fn validate_args(args: &BenchArgs) -> Result<()> {
     if let Some(json_path) = &args.output_json {
         if let Some(parent) = json_path.parent() {
             if !parent.as_os_str().is_empty() && !parent.exists() {
-                anyhow::bail!(
-                    "Output directory does not exist: {}",
-                    parent.display()
-                );
+                anyhow::bail!("Output directory does not exist: {}", parent.display());
             }
         }
     }

--- a/src/cli/distributed.rs
+++ b/src/cli/distributed.rs
@@ -383,15 +383,12 @@ async fn benchmark_distributed_inference(
     let total_failed = all_stats.iter().map(|s| s.failed_requests).sum::<u64>();
     let total_tokens = all_stats.iter().map(|s| s.total_tokens).sum::<u32>();
 
-    let avg_response_time = if total_successful > 0 {
-        all_stats
-            .iter()
-            .map(|s| s.total_response_time.as_millis() as u64)
-            .sum::<u64>()
-            / total_successful
-    } else {
-        0
-    };
+    let avg_response_time = all_stats
+        .iter()
+        .map(|s| s.total_response_time.as_millis() as u64)
+        .sum::<u64>()
+        .checked_div(total_successful)
+        .unwrap_or(0);
 
     println!("\n=== Benchmark Results ===");
     println!("Total Duration: {:?}", total_duration);

--- a/src/cli/logging_audit.rs
+++ b/src/cli/logging_audit.rs
@@ -3341,7 +3341,7 @@ mod tests {
 
     #[test]
     fn test_validate_export_path_unsupported_extension() {
-        let path = PathBuf::from("/tmp/file.exe");
+        let path = std::env::temp_dir().join("file.exe");
         let result = validate_export_path(&path);
         assert!(result.is_err());
         assert!(
@@ -3354,7 +3354,7 @@ mod tests {
 
     #[test]
     fn test_validate_export_path_no_extension() {
-        let path = PathBuf::from("/tmp/file");
+        let path = std::env::temp_dir().join("file");
         let result = validate_export_path(&path);
         assert!(result.is_err());
         assert!(

--- a/src/cli/models.rs
+++ b/src/cli/models.rs
@@ -378,7 +378,7 @@ pub async fn execute(args: ModelsArgs, config: &Config) -> Result<()> {
             }
 
             let mut entries: Vec<_> = registry.entries.values().collect();
-            entries.sort_by(|a, b| b.use_count.cmp(&a.use_count));
+            entries.sort_by_key(|b| std::cmp::Reverse(b.use_count));
 
             println!("{:<35} {:<10} {:<25} Tags", "Model", "Uses", "Last Used");
             println!("{}", "─".repeat(90));

--- a/src/interfaces/desktop/model_repository.rs
+++ b/src/interfaces/desktop/model_repository.rs
@@ -536,7 +536,7 @@ impl ModelDownloadManager {
                     != (downloaded - chunk.len() as u64) * 20 / total_size
             {
                 let elapsed = start_time.elapsed().as_secs();
-                let speed = if elapsed > 0 { downloaded / elapsed } else { 0 };
+                let speed = downloaded.checked_div(elapsed).unwrap_or(0);
                 let eta = if speed > 0 && total_size > downloaded {
                     Some((total_size - downloaded) / speed)
                 } else {

--- a/src/interfaces/desktop/security.rs
+++ b/src/interfaces/desktop/security.rs
@@ -288,7 +288,7 @@ impl SecurityManager {
 
         // Return most recent events first
         let mut sorted_events = events.clone();
-        sorted_events.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        sorted_events.sort_by_key(|b| std::cmp::Reverse(b.timestamp));
         sorted_events.truncate(limit);
 
         Ok(sorted_events)

--- a/src/marketplace.rs
+++ b/src/marketplace.rs
@@ -1068,7 +1068,7 @@ impl ModelMarketplace {
                 .retain(|pkg| pkg.name.contains(filter_str) || pkg.model_id.contains(filter_str));
         }
 
-        packages.sort_by(|a, b| a.install_date.cmp(&b.install_date));
+        packages.sort_by_key(|a| a.install_date);
         Ok(packages)
     }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -913,7 +913,10 @@ fn read_gguf_value(cursor: &mut Cursor<&[u8]>, value_type: u32) -> Result<String
             let elem_type = cursor.read_u32::<LittleEndian>()?;
             let count = cursor.read_u64::<LittleEndian>()?;
             if count > 10_000_000 {
-                return Err(anyhow::anyhow!("GGUF array count {} exceeds sanity limit", count));
+                return Err(anyhow::anyhow!(
+                    "GGUF array count {} exceeds sanity limit",
+                    count
+                ));
             }
             for _ in 0..count {
                 skip_gguf_value(cursor, elem_type)?;
@@ -948,7 +951,10 @@ fn skip_gguf_value(cursor: &mut Cursor<&[u8]>, value_type: u32) -> Result<()> {
             let elem_type = cursor.read_u32::<LittleEndian>()?;
             let count = cursor.read_u64::<LittleEndian>()?;
             if count > 10_000_000 {
-                return Err(anyhow::anyhow!("GGUF array count {} exceeds sanity limit", count));
+                return Err(anyhow::anyhow!(
+                    "GGUF array count {} exceeds sanity limit",
+                    count
+                ));
             }
             for _ in 0..count {
                 skip_gguf_value(cursor, elem_type)?;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -181,7 +181,7 @@ impl ModelManager {
             }
         }
 
-        models.sort_by(|a, b| b.modified.cmp(&a.modified));
+        models.sort_by_key(|b| std::cmp::Reverse(b.modified));
         info!(
             "Found {} models under {}",
             models.len(),

--- a/src/performance_baseline.rs
+++ b/src/performance_baseline.rs
@@ -522,8 +522,8 @@ impl PerformanceBaseline {
             .filter(|m| m.backend_type == "onnx")
             .collect();
 
-        gguf_metrics.sort_by(|a, b| a.model_size_mb.cmp(&b.model_size_mb));
-        onnx_metrics.sort_by(|a, b| a.model_size_mb.cmp(&b.model_size_mb));
+        gguf_metrics.sort_by_key(|a| a.model_size_mb);
+        onnx_metrics.sort_by_key(|a| a.model_size_mb);
 
         report.push_str("## GGUF Backend Results\n\n");
         report.push_str("| Model | Size (MB) | Avg Latency (ms) | P99 Latency (ms) | RPS | Memory (MB) | Loading (ms) |\n");

--- a/src/upgrade/backup.rs
+++ b/src/upgrade/backup.rs
@@ -220,7 +220,7 @@ impl BackupManager {
 
         // Sort by creation date (newest first)
         let mut backups = all_metadata;
-        backups.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        backups.sort_by_key(|b| std::cmp::Reverse(b.created_at));
 
         Ok(backups)
     }
@@ -344,7 +344,7 @@ impl BackupManager {
 
         // Sort by creation date (oldest first)
         let mut sorted_backups = backups;
-        sorted_backups.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+        sorted_backups.sort_by_key(|a| a.created_at);
 
         // Keep only the most recent max_backups
         let total_backups = sorted_backups.len();

--- a/tests/metal_performance_tests.rs
+++ b/tests/metal_performance_tests.rs
@@ -160,9 +160,7 @@ mod metal_tests {
             }
         };
 
-        let model_size_bytes = std::fs::metadata(&model_file)
-            .map(|m| m.len())
-            .unwrap_or(0);
+        let model_size_bytes = std::fs::metadata(&model_file).map(|m| m.len()).unwrap_or(0);
         let model_size_mb = model_size_bytes as f64 / 1_048_576.0;
         println!("Model:        {}", model_file.display());
         println!("Model size:   {:.0} MB", model_size_mb);
@@ -272,12 +270,8 @@ mod metal_tests {
             println!("Latency med:  {:.1} ms", median_ms);
             println!("Total tokens: {}", total_tokens);
             println!("Load time:    {:?}", load_time);
-            println!(
-                "\nGPU memory:   check Activity Monitor > GPU tab during inference"
-            );
-            println!(
-                "Layer offload: check logs for 'offloaded X/X layers to GPU'"
-            );
+            println!("\nGPU memory:   check Activity Monitor > GPU tab during inference");
+            println!("Layer offload: check logs for 'offloaded X/X layers to GPU'");
             println!(
                 "\nTo contribute these results to issue #7:\n  https://github.com/ringo380/inferno/issues/7"
             );


### PR DESCRIPTION
Greens two CI jobs on `main`: **Linting** and **Test Suite (windows-latest)**. Distinct from the known `lettre` RUSTSEC advisory the Security Audit job flags.

## 1. Linting -> `cargo fmt --check`
`bench.rs` and `models/mod.rs` (from recent feature PRs) had unformatted code. Ran `cargo fmt`.

## 2. Linting -> `cargo clippy --all-targets --all-features -- -D warnings`
Fixing fmt let the Linting job finally reach the clippy step, which then failed on lints from the newer clippy CI uses (rust 1.96) that local 1.90 doesn't even have. Resolved all 14, behavior-preserving:
- **unnecessary_sort_by** (x12): `sort_by(|a,b| a.k.cmp(&b.k))` -> `sort_by_key(|a| a.k)`; descending variants -> `sort_by_key(|b| std::cmp::Reverse(b.k))`. All keys are Copy (timestamps/sizes/counts).
- **manual_checked_ops** (x2): guarded `if d > 0 { n / d } else { 0 }` -> `n.checked_div(d).unwrap_or(0)` (same zero-divisor behavior).

## 3. Test Suite (windows-latest) -> 5 failing tests
`cli::audit` / `cli::logging_audit` export-validation tests hardcoded `/tmp/...`; on Windows that parent dir doesn't exist so the directory check fired first. Switched to `std::env::temp_dir()`.

## Verification (matched CI toolchain, rust 1.96)
```
cargo +stable clippy --all-targets --all-features -- -D warnings   # exit 0
cargo +stable fmt --check                                          # clean
cargo test --lib validate_export                                   # 11 passed
```

## Still red after this (separate follow-ups)
- Security Audit = `lettre RUSTSEC-2026-0141` (known)
- Docs build = rustdoc html-tags + README drift
- quality-gates matrix (container builds, license compliance, etc.) - newly *visible* after #21 unblocked that workflow