### PR TITLE
fix(security): green the CI Security Audit (lettre upgrade + rsa advisory ignore)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,11 @@
+# cargo-audit configuration.
+# Advisories listed here are acknowledged and intentionally not failing CI.
+[advisories]
+ignore = [
+    # rsa "Marvin Attack" timing sidechannel. No fixed upgrade is available.
+    # rsa is pulled in transitively by jsonwebtoken's rust_crypto backend; we
+    # only issue and verify HMAC (HS256) JWTs and never use RSA-based JWT
+    # algorithms, so the vulnerable code path is not exercised. Revisit if a
+    # fixed rsa release ships or if RSA JWT support is ever added.
+    "RUSTSEC-2023-0071",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,16 +877,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chumsky"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
-dependencies = [
- "hashbrown 0.14.5",
- "stacker",
-]
-
-[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,7 +1556,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.1",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1845,7 +1835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.1",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2575,7 +2565,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
- "allocator-api2",
 ]
 
 [[package]]
@@ -3413,13 +3402,12 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "lettre"
-version = "0.11.18"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cb54db6ff7a89efac87dba5baeac57bb9ccd726b49a9b6f21fb92b3966aaf56"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "chumsky",
  "email-encoding",
  "email_address",
  "fastrand",
@@ -5108,15 +5096,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "psm"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "pxfm"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5670,7 +5649,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.1",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6312,19 +6291,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "stacker"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cddb07e32ddb770749da91081d8d0ac3a16f1a569a18b20348cd371f5dead06b"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "psm",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "static_assertions"
@@ -6986,7 +6952,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.1",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8180,7 +8146,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Greens the **Security Audit** job in `ci.yml`, which was the last red workflow on `main`. `cargo audit` was failing on two advisories:

| Advisory | Crate | Resolution |
|----------|-------|------------|
| RUSTSEC-2026-0141 | lettre 0.11.18 | Upgrade to 0.11.22 |
| RUSTSEC-2023-0071 | rsa 0.9.10 | Ignore (no fix available) |

### lettre (RUSTSEC-2026-0141)
"TLS hostname verification disabled when using Boring TLS backend." We don't use the Boring backend (the `email-alerts` feature uses native-tls or rustls), but upgrading to 0.11.22 is the clean fix. Verified the `email-alerts` feature still compiles. lettre isn't in the desktop crate, so only the root `Cargo.lock` changes.

### rsa (RUSTSEC-2023-0071)
The "Marvin Attack" timing sidechannel - **no fixed upgrade is available**. `rsa` is pulled in transitively by `jsonwebtoken`'s `rust_crypto` backend (chosen in #25 for clean cross-compilation). We only issue and verify HMAC (HS256) JWTs and never use RSA-based algorithms, so the vulnerable path isn't exercised. Added `.cargo/audit.toml` ignoring it with that justification; revisit if a fixed `rsa` ships or RSA JWT support is added.

## Verification
- `cargo audit` now exits 0 locally (24 unmaintained *warnings* remain, which don't fail the audit).
- `cargo check --features email-alerts-rustls` compiles cleanly with lettre 0.11.22.
