### PR TITLE
fix(verify): run integration suites with backend features and a timeout

### DIFF
--- a/verify.sh
+++ b/verify.sh
@@ -115,11 +115,31 @@ INTEGRATION_TESTS=(
     "metrics_thread_safety"
 )
 
+# BackendType::Gguf and ::Onnx are feature-gated, so the suites that name them
+# fail to compile without these. Matches the features used by CI.
+INTEGRATION_FEATURES="gguf,onnx"
+
+# Cap each suite so one hung test cannot block the whole run. timeout is stock
+# on Linux and ships via coreutils on macOS; run uncapped when it is absent.
+TIMEOUT_CMD=()
+if command -v timeout &> /dev/null; then
+    TIMEOUT_CMD=(timeout 300)
+elif command -v gtimeout &> /dev/null; then
+    TIMEOUT_CMD=(gtimeout 300)
+fi
+
 for test in "${INTEGRATION_TESTS[@]}"; do
-    if cargo test --test "$test" > /dev/null 2>&1; then
+    log=$(mktemp "${TMPDIR:-/tmp}/inferno-verify-${test}.XXXXXX")
+    if "${TIMEOUT_CMD[@]}" cargo test --test "$test" --features "$INTEGRATION_FEATURES" > "$log" 2>&1; then
         print_status 0 "Integration: $test"
+        rm -f "$log"
     else
-        print_status 1 "Integration: $test"
+        rc=$?
+        if [ $rc -eq 124 ]; then
+            print_status 1 "Integration: $test (timed out after 300s, log: $log)"
+        else
+            print_status 1 "Integration: $test (log: $log)"
+        fi
     fi
 done
 echo


### PR DESCRIPTION
## Problem

`verify.sh` ran its integration loop as `cargo test --test "$test"` with no
features. `BackendType::Gguf` and `::Onnx` are feature-gated, so every suite
naming them failed to **compile** rather than run:

```
error[E0599]: no variant, associated function, or constant named `Gguf`
              found for enum `BackendType` in the current scope
```

CI already passes `gguf,onnx` for these (ci.yml line 73); the script never did.

Two related problems made this hard to act on:

- `feature_integration_tests` hangs indefinitely (blocked, 0% CPU — confirmed
  over 26 minutes), so a full run never reached the security audit or the
  summary line.
- Output went to `/dev/null`, leaving a bare `✗` with no diagnostic.

## Change

- Pass `--features "gguf,onnx"`, matching CI.
- Cap each suite and report a timeout as such. `timeout` is stock on Linux and
  ships via coreutils on macOS, so it is used only when present and the run is
  uncapped otherwise.
- Log each suite to a temp file; print the path on failure, remove on success.

## Result

`integration_tests` goes from failing to passing, and the script now runs to
completion instead of blocking forever:

```
✓ Integration: integration_tests
✗ Integration: feature_integration_tests (timed out after 300s, log: ...)
```

Reaching the end also makes `cargo audit` run again, which currently reports
advisories in quick-xml, quinn-proto and crossbeam-epoch. Those are left for a
separate change.

## Scope

The remaining integration failures are pre-existing API drift (`missing field
retry_config`, `no method discover_models`) and are unchanged here — they now
simply fail for the honest reason. `verify.sh` still exits 1 until that is
addressed.

Verified locally: bash 3.2 syntax check, empty/populated timeout-array
expansion, and `mktemp` template checked against both BSD and GNU (`mktemp -t`
would have broken on Linux).