### PR TITLE
fix(tests): stop feature_integration_tests hanging on gpu monitor

### DIFF
--- a/tests/feature_integration_tests.rs
+++ b/tests/feature_integration_tests.rs
@@ -3,7 +3,6 @@ use predicates::prelude::*;
 use std::fs;
 use std::time::Duration;
 use tempfile::tempdir;
-use tokio::time::sleep;
 
 /// Test A/B Testing Feature Integration
 #[test]
@@ -100,12 +99,19 @@ fn test_gpu_list_command() {
 
 #[test]
 fn test_gpu_monitor_command() {
+    // `gpu monitor` is a live watcher: it loops until interrupted and never
+    // exits on its own. Cap it so a stuck watcher cannot block the suite, and
+    // assert it reached the monitor loop before being killed.
     let mut cmd = Command::cargo_bin("inferno").unwrap();
-    cmd.arg("gpu").arg("monitor").arg("--interval").arg("1");
+    cmd.arg("gpu")
+        .arg("monitor")
+        .arg("--interval")
+        .arg("1")
+        .timeout(Duration::from_secs(10));
 
-    cmd.assert().success().stdout(predicate::str::contains(
-        "GPU management functionality is not yet implemented",
-    ));
+    cmd.assert()
+        .interrupted()
+        .stdout(predicate::str::contains("Monitoring GPUs"));
 }
 
 /// Test Model Versioning Feature Integration


### PR DESCRIPTION
Closes #34.

## Root cause

`test_gpu_monitor_command` ran `inferno gpu monitor --interval 1` and waited for it to exit. `GpuCommand::Monitor` (`src/cli/gpu.rs:346`) is a live watcher - an unbounded `loop` that prints and sleeps until interrupted, exactly as its "press Ctrl+C to stop" banner says. The test could never terminate, and it blocked the entire suite (test binary parked at 0% CPU).

Confirmed by killing the `inferno gpu monitor` child mid-run: the suite immediately completed.

## Fix

Cap the child with `assert_cmd`'s `timeout` and assert it reached the monitor loop before being killed. This tests the behaviour the command actually has, rather than asserting a stub message it stopped printing long ago. Also removes the unused `tokio::time::sleep` import in the same file (pre-existing dead import, flagged by clippy under `--features gguf,onnx`).

## Verification (local)

- Suite completes in **11.14s** (previously never).
- Mutation-checked both halves of the assertion:
  - make the loop `break` -> fails with `Unexpected completion`
  - change the banner text -> fails with `failed var.contains(Monitoring GPUs)`
- `cargo clippy --all-targets --all-features -- -D warnings` -> 0 warnings
- `cargo clippy --test feature_integration_tests --features gguf,onnx -- -D warnings` -> clean
- `cargo fmt -- --check` -> clean

## Out of scope

12 tests in this suite still fail on stale `"... not yet implemented"` assertions against commands that are now implemented (e.g. `cache status` was renamed to `cache stats`). That is the API drift tracked in #33, not the hang.