### PR TITLE
fix(tests): update feature_integration_tests to current CLI surface

### DIFF
--- a/tests/feature_integration_tests.rs
+++ b/tests/feature_integration_tests.rs
@@ -26,9 +26,10 @@ fn test_ab_testing_start_command() {
         .arg("--treatment-model")
         .arg("model2");
 
-    cmd.assert().success().stdout(predicate::str::contains(
-        "A/B testing functionality is not yet implemented",
-    ));
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("A/B Test Configuration"))
+        .stdout(predicate::str::contains("Name: test1"));
 }
 
 #[test]
@@ -38,7 +39,7 @@ fn test_ab_testing_list_command() {
 
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("Would list all A/B tests"));
+        .stdout(predicate::str::contains("A/B Tests"));
 }
 
 /// Test Job Queue Feature Integration
@@ -58,7 +59,7 @@ fn test_queue_list_empty() {
 
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("No job queues found"));
+        .stdout(predicate::str::contains("No queues found"));
 }
 
 #[test]
@@ -70,11 +71,14 @@ fn test_queue_create_command() {
         .arg("test-queue")
         .arg("--max-concurrent")
         .arg("5")
-        .arg("--priority-enabled");
+        .arg("test-queue-id");
 
-    cmd.assert().success().stdout(predicate::str::contains(
-        "Job queue management functionality is not yet implemented",
-    ));
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Queue 'test-queue-id' created successfully",
+        ))
+        .stdout(predicate::str::contains("Max concurrent jobs: 5"));
 }
 
 /// Test GPU Management Feature Integration
@@ -92,9 +96,11 @@ fn test_gpu_list_command() {
     let mut cmd = Command::cargo_bin("inferno").unwrap();
     cmd.arg("gpu").arg("list");
 
-    cmd.assert().success().stdout(predicate::str::contains(
-        "GPU management functionality is not yet implemented",
-    ));
+    // Output depends on the host: a table of GPUs where one is present, the
+    // empty-set message otherwise. Both are a successful listing.
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("No GPUs found").or(predicate::str::contains("Vendor")));
 }
 
 #[test]
@@ -126,12 +132,17 @@ fn test_versioning_cli_integration() {
 
 #[test]
 fn test_versioning_list_command() {
-    let mut cmd = Command::cargo_bin("inferno").unwrap();
-    cmd.arg("version").arg("list");
+    // The version registry lives at "./models/versions" relative to the working
+    // directory (VersioningConfig::default), so run from a tempdir to get an
+    // empty registry instead of whatever exists in the checkout.
+    let temp_dir = tempdir().unwrap();
 
-    cmd.assert().success().stdout(predicate::str::contains(
-        "Model versioning functionality is not yet implemented",
-    ));
+    let mut cmd = Command::cargo_bin("inferno").unwrap();
+    cmd.arg("version").arg("list").current_dir(temp_dir.path());
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("No models found in registry"));
 }
 
 #[test]
@@ -140,18 +151,31 @@ fn test_versioning_create_command() {
     let model_path = temp_dir.path().join("test.gguf");
     fs::write(&model_path, b"GGUF\x00\x00\x00\x01test data").unwrap();
 
+    // `version create` writes its registry to "./models/versions" relative to the
+    // working directory, so run from the tempdir to keep it out of the checkout.
     let mut cmd = Command::cargo_bin("inferno").unwrap();
     cmd.arg("version")
         .arg("create")
-        .arg("--model")
-        .arg("test-model")
+        .arg("--model-type")
+        .arg("llm")
+        .arg("--architecture")
+        .arg("transformer")
+        .arg("--framework")
+        .arg("onnx")
+        .arg("--framework-version")
+        .arg("1.0")
+        .arg("--format")
+        .arg("gguf")
+        .arg("--created-by")
+        .arg("integration-test")
         .arg("--version")
         .arg("1.0.0")
-        .arg("--file")
-        .arg(model_path.to_str().unwrap());
+        .arg("test-model")
+        .arg(model_path.to_str().unwrap())
+        .current_dir(temp_dir.path());
 
     cmd.assert().success().stdout(predicate::str::contains(
-        "Model versioning functionality is not yet implemented",
+        "Model version created successfully",
     ));
 }
 
@@ -170,9 +194,9 @@ fn test_monitoring_status_command() {
     let mut cmd = Command::cargo_bin("inferno").unwrap();
     cmd.arg("monitor").arg("status");
 
-    cmd.assert().success().stdout(predicate::str::contains(
-        "Real-time monitoring functionality is not yet implemented",
-    ));
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Monitoring System Status"));
 }
 
 /// Test Audit Feature Integration
@@ -190,9 +214,9 @@ fn test_audit_query_command() {
     let mut cmd = Command::cargo_bin("inferno").unwrap();
     cmd.arg("audit").arg("query").arg("--limit").arg("10");
 
-    cmd.assert().success().stdout(predicate::str::contains(
-        "Audit logging functionality is not yet implemented",
-    ));
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("No events found"));
 }
 
 /// Test Distributed Processing Feature Integration
@@ -208,11 +232,11 @@ fn test_distributed_cli_integration() {
 #[test]
 fn test_distributed_status_command() {
     let mut cmd = Command::cargo_bin("inferno").unwrap();
-    cmd.arg("distributed").arg("status");
+    cmd.arg("distributed").arg("stats");
 
-    cmd.assert().success().stdout(predicate::str::contains(
-        "Distributed processing functionality is not yet implemented",
-    ));
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Distributed Configuration"));
 }
 
 /// Test Metrics Feature Integration
@@ -228,11 +252,11 @@ fn test_metrics_cli_integration() {
 #[test]
 fn test_metrics_show_command() {
     let mut cmd = Command::cargo_bin("inferno").unwrap();
-    cmd.arg("metrics").arg("show");
+    cmd.arg("metrics").arg("snapshot");
 
-    cmd.assert().success().stdout(predicate::str::contains(
-        "Metrics functionality is not yet implemented",
-    ));
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("inference_metrics"));
 }
 
 /// Test Cache Feature Integration
@@ -248,11 +272,11 @@ fn test_cache_cli_integration() {
 #[test]
 fn test_cache_status_command() {
     let mut cmd = Command::cargo_bin("inferno").unwrap();
-    cmd.arg("cache").arg("status");
+    cmd.arg("cache").arg("stats");
 
-    cmd.assert().success().stdout(predicate::str::contains(
-        "Model cache functionality is not yet implemented",
-    ));
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Model Cache Statistics"));
 }
 
 /// Test Response Cache Feature Integration


### PR DESCRIPTION
Follow-up to #35. Takes `feature_integration_tests` from **17 passed / 12 failed** to **29 passed / 0 failed**.

## What was wrong

Every failing test asserted a `"... functionality is not yet implemented"` stub message against a command that has since been implemented. Three had also drifted structurally:

| Test | Drift |
|---|---|
| `cache status` | renamed to `cache stats` |
| `metrics show` | renamed to `metrics snapshot` |
| `distributed status` | renamed to `distributed stats` |
| `queue create` | gained required `<QUEUE_ID>` positional, dropped `--priority-enabled` |
| `version create` | redesigned: positional `<MODEL_NAME> <MODEL_FILE>` + 6 required flags |

The rest now assert real output (`No events found`, `Monitoring System Status`, `No queues found`, ...). Each expectation was taken from running the command, not from reading the source.

## Test isolation bug found along the way

`version create` was writing a `models/` tree **into the checkout**. `VersioningConfig::default` (`src/versioning.rs:376`) hardcodes `storage_path: PathBuf::from("./models/versions")` - relative to the working directory, and it does not honour `INFERNO_MODELS_DIR`. Both versioning tests now run via `current_dir(temp_dir)`, so the suite leaves the tree clean.

Worth noting as a product question separate from this PR: `version` ignoring `INFERNO_MODELS_DIR` and writing to CWD is arguably a bug in its own right, not just a test inconvenience.

## Verification (local)

- `cargo test --test feature_integration_tests --features gguf,onnx` -> **29 passed; 0 failed** in 11.4s
- `git status` clean after the run (no `models/` pollution)
- Mutation-checked `test_versioning_create_command` by dropping a required flag -> fails with `Unexpected failure ... required arguments were not provided`
- `cargo clippy --all-targets --all-features -- -D warnings` -> 0 warnings
- `cargo fmt -- --check` -> clean

`gpu list` accepts either the GPU table or the empty-set message, since that output is host-dependent (table on this M4 Max, empty on a GPU-less CI runner).