### PR TITLE
fix(tests): repair platform_integration and batch_queue_integration_tests

### DIFF
--- a/tests/batch_queue_integration_tests.rs
+++ b/tests/batch_queue_integration_tests.rs
@@ -1,7 +1,7 @@
 use inferno::{
     backends::InferenceParams,
     batch::queue::{
-        BatchJob, JobPriority, JobQueue, JobQueueConfig, JobQueueManager, JobStatus, QueueStatus,
+        BatchJob, JobPriority, JobQueueConfig, JobQueueManager, JobStatus, RetryConfig,
     },
     batch::{BatchConfig, BatchInput},
 };
@@ -48,6 +48,7 @@ async fn test_batch_queue_basic_operations() {
         timeout_minutes: Some(30),
         retry_count: 0,
         max_retries: 3,
+        retry_config: RetryConfig::default(),
         created_at: SystemTime::now(),
         scheduled_at: None,
         tags: HashMap::new(),
@@ -200,6 +201,7 @@ async fn test_job_retry_functionality() {
         timeout_minutes: Some(30),
         retry_count: 0,
         max_retries: 3,
+        retry_config: RetryConfig::default(),
         created_at: SystemTime::now(),
         scheduled_at: None,
         tags: HashMap::new(),

--- a/tests/platform_integration.rs
+++ b/tests/platform_integration.rs
@@ -2,12 +2,32 @@
 //!
 //! Comprehensive tests for the enhanced Inferno platform capabilities
 
-use inferno::{PlatformInfo, Result, init_platform};
+use inferno::{InfernoError, PlatformInfo, Result, init_platform};
+use std::sync::Once;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// `init_platform` installs a global tracing dispatcher, which can only be set
+/// once per process. Tests in a suite share one process, so route every call
+/// through a `Once` - otherwise whichever test runs second fails on the
+/// already-set dispatcher.
+fn ensure_platform_initialized() {
+    static INIT: Once = Once::new();
+    static INIT_OK: AtomicBool = AtomicBool::new(false);
+
+    INIT.call_once(|| {
+        INIT_OK.store(init_platform().is_ok(), Ordering::SeqCst);
+    });
+
+    assert!(
+        INIT_OK.load(Ordering::SeqCst),
+        "init_platform() failed on its first call"
+    );
+}
 
 #[tokio::test]
 async fn test_platform_initialization() -> Result<()> {
     // Test platform initialization
-    init_platform()?;
+    ensure_platform_initialized();
     println!("✅ Platform initialized successfully");
     Ok(())
 }
@@ -113,7 +133,7 @@ fn test_tauri_integration() {
 #[tokio::test]
 async fn test_platform_enhancement_integration() -> Result<()> {
     // Initialize the platform
-    init_platform()?;
+    ensure_platform_initialized();
 
     // Get platform information
     let info = PlatformInfo::new();


### PR DESCRIPTION
First slice of #33. Two suites compile and pass: **platform_integration 7/7**, **batch_queue_integration_tests 6/6**.

## platform_integration

- `InfernoError` was referenced but never imported.
- `init_platform()` installs a **global** tracing dispatcher, settable only once per process. Two tests in the shared binary both called it, so whichever ran second failed with `a global default trace dispatcher has already been set` - an order-dependent failure, not a product break. Calls now go through a `Once` helper that still asserts the first call succeeds, so it stays honest instead of just swallowing the error. Verified green both parallel and `--test-threads=1`.

## batch_queue_integration_tests

- `BatchJob` gained a `retry_config` field; both initializers now set `RetryConfig::default()`. `can_retry_job` still reads the legacy `max_retries` field, so existing retry expectations hold.
- Removed `JobQueue`/`QueueStatus` imports - unused, and masked while the file didn't compile.

## Systemic finding worth acting on separately

**CI never compiles these suites, which is how they rotted.** Every suite in #33 is declared `test = false` in `Cargo.toml` (line 274+). That excludes them from `cargo test` (intended, per the v0.6.1 fast-test strategy) **but also from `--all-targets`** - so the CI lint gate skips them too:

```
cargo clippy --all-targets --all-features -- -D warnings   # EXIT=0, 0 warnings
cargo test --test cross_component_integration_tests --all-features --no-run   # 163 errors
```

Nothing in CI or the default test run has been compiling this code. `./verify.sh` does run them (since #31), so local verification is currently the only thing that would catch this drift. Filing that thought on #33.

## Remaining in #33

~575 errors across 10 suites: cross_component (163), performance_stress (90), batch_processing (78), dashboard_api_workflow (62), conversion (55), cache_persistence (44), audit_system (30), backend (25), dashboard_api (15), metrics_thread_safety (11).

## Verification (local)

- Both suites pass; `cargo fmt -- --check` clean; clippy clean on both targets (the pre-existing `unexpected cfg: tauri-app` warning is present on `main` and untouched here).