### PR TITLE
fix(tests): repair metrics_thread_safety for nested MetricsSnapshot

### DIFF
--- a/tests/metrics_thread_safety.rs
+++ b/tests/metrics_thread_safety.rs
@@ -27,7 +27,7 @@ async fn test_metrics_collector_concurrent_access() {
                     model_name: format!("model-{}", i % 3),
                     input_length: 50 + j,
                     output_length: 100 + j,
-                    duration: Duration::from_millis(10 + j),
+                    duration: Duration::from_millis((10 + j) as u64),
                     success: j % 10 != 0,
                 };
                 collector_clone.record_inference(event);
@@ -50,26 +50,29 @@ async fn test_metrics_collector_concurrent_access() {
         .await
         .expect("Failed to get snapshot");
 
+    // Request counters now live under the inference_metrics section
+    let metrics = &snapshot.inference_metrics;
+
     // We sent 10 tasks * 100 events = 1000 events
     assert!(
-        snapshot.total_requests >= 1000,
+        metrics.total_requests >= 1000,
         "Expected at least 1000 requests, got {}",
-        snapshot.total_requests
+        metrics.total_requests
     );
 
     // Success rate should be around 90% (j % 10 != 0)
     let success_rate =
-        (snapshot.successful_requests as f64) / (snapshot.total_requests as f64) * 100.0;
+        (metrics.successful_requests as f64) / (metrics.total_requests as f64) * 100.0;
     assert!(
-        success_rate >= 85.0 && success_rate <= 95.0,
+        (85.0..=95.0).contains(&success_rate),
         "Expected ~90% success rate, got {:.2}%",
         success_rate
     );
 
     println!("✅ Thread safety test passed!");
-    println!("   Total requests: {}", snapshot.total_requests);
-    println!("   Successful: {}", snapshot.successful_requests);
-    println!("   Failed: {}", snapshot.failed_requests);
+    println!("   Total requests: {}", metrics.total_requests);
+    println!("   Successful: {}", metrics.successful_requests);
+    println!("   Failed: {}", metrics.failed_requests);
     println!("   Success rate: {:.2}%", success_rate);
 }
 
@@ -106,9 +109,12 @@ async fn test_metrics_collector_clone_safety() {
         .get_snapshot()
         .await
         .expect("Failed to get snapshot");
-    assert_eq!(snapshot.total_requests, 2, "Expected 2 requests");
     assert_eq!(
-        snapshot.successful_requests, 2,
+        snapshot.inference_metrics.total_requests, 2,
+        "Expected 2 requests"
+    );
+    assert_eq!(
+        snapshot.inference_metrics.successful_requests, 2,
         "Expected 2 successful requests"
     );
 


### PR DESCRIPTION
Another slice of #33. **metrics_thread_safety: 3/3 passing.**

`MetricsSnapshot` was restructured: `total_requests`/`successful_requests`/`failed_requests` moved from the top level into the `inference_metrics` section (alongside `system_metrics` and `model_metrics`). Every assertion in the suite still read them off the snapshot root.

- Read counters via `snapshot.inference_metrics`.
- Cast the loop counter for `Duration::from_millis` - it infers as `u32` from `input_length`, but `from_millis` takes `u64`.
- Success-rate bound uses `(85.0..=95.0).contains(..)`, which clippy prefers over the chained comparison.

This suite is worth having back: it is the real check that `MetricsCollector` is `Send + Sync` and aggregates correctly across 10 concurrent tasks / 1000 events after the `Arc<T>` refactor.

## Verification (local)

- `cargo test --test metrics_thread_safety --features gguf,onnx` -> **3 passed; 0 failed**
- `cargo fmt -- --check` clean, clippy clean on the target