### PR TITLE
Rewrite cross_component_integration_tests against the real component APIs

### DIFF
--- a/tests/cross_component_integration_tests.rs
+++ b/tests/cross_component_integration_tests.rs
@@ -1,1097 +1,531 @@
+//! Cross-component integration tests exercised against the real Inferno APIs.
+//!
+//! These verify that the independently-tested components (model discovery,
+//! model cache, response cache, audit log, job queue) cooperate correctly.
+//!
+//! Model-free tests (resilience, concurrency) run everywhere. The two tests
+//! that load and run a model are gated on `INFERNO_TEST_MODEL` (a path to a
+//! small `.gguf`) and skip cleanly when it is unset. Audit event counts are
+//! asserted after every spawned task has joined and are isolated by a unique
+//! actor, so they are exact rather than timing-dependent.
+
 use anyhow::Result;
-use axum::{
-    body::Body,
-    http::{Method, Request, StatusCode},
-};
-use hyper::body::to_bytes;
 use inferno::{
-    InfernoError,
-    // Audit and security
-    audit::{Actor, ActorType, AuditConfig, AuditEvent, AuditSystem, EventType, Severity},
-    // Core components
-    backends::{Backend, BackendConfig, BackendHandle, BackendType, InferenceParams},
-    // Batch processing
+    audit::{
+        Actor, ActorType, AuditConfiguration, AuditEvent, AuditLogger, AuditQuery, EventContext,
+        EventDetails, EventOutcome, EventType, LogLevel, Resource, ResourceType, Severity,
+    },
+    backends::{BackendConfig, InferenceParams},
     batch::{
         BatchConfig, BatchInput,
-        processor::{BatchProcessor, ProcessorConfig},
-        queue::{BatchJob, JobPriority, JobQueue, JobQueueConfig, JobQueueManager, JobStatus},
-        scheduler::{
-            BatchScheduler, OneTimeSchedule, ScheduleEntry, ScheduleType, SchedulerConfig,
+        queue::{
+            BatchJob, JobPriority, JobQueueConfig, JobQueueManager, JobStatus,
+            ResourceRequirements, RetryConfig,
         },
     },
-
-    cache::{CacheConfig, ModelCache, WarmupStrategy},
-    // Configuration
-    config::Config,
-
-    // Model conversion
-    conversion::{ConversionConfig, ModelConverter, ModelFormat, OptimizationLevel},
-
-    // Dashboard and API
-    dashboard::{CreateDeploymentRequest, CreateModelRequest, DashboardConfig, DashboardServer},
-
-    metrics::MetricsCollector,
-
+    cache::{CacheConfig, ModelCache},
     models::{ModelInfo, ModelManager},
-    // Response caching
-    response_cache::{CacheKey, ResponseCache, ResponseCacheConfig},
-
-    security::{SecurityConfig, SecurityManager},
-};
-use serde_json::{Value, json};
-use std::{
-    collections::HashMap,
-    path::PathBuf,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
+    response_cache::{
+        CacheKey, HashAlgorithm, ResponseCache, ResponseCacheConfig, ResponseMetadata,
     },
-    time::{Duration, SystemTime},
 };
+use std::{collections::HashMap, path::PathBuf, sync::Arc, time::SystemTime};
 use tempfile::TempDir;
-use tokio::{
-    fs,
-    sync::{Mutex, RwLock},
-    time::{sleep, timeout},
-};
-use tower::ServiceExt;
 use uuid::Uuid;
 
-/// Comprehensive test utilities for cross-component integration
-mod integration_test_utils {
-    use super::*;
+/// Real components wired together for a single test. `_temp` keeps the backing
+/// directories alive for the lifetime of the environment.
+struct TestEnv {
+    model_cache: Arc<ModelCache>,
+    audit: Arc<AuditLogger>,
+    queue: Arc<JobQueueManager>,
+    response_cache: Arc<ResponseCache>,
+    models: Vec<ModelInfo>,
+    _temp: TempDir,
+}
 
-    pub async fn setup_complete_test_environment(temp_dir: &TempDir) -> Result<TestEnvironment> {
-        let models_dir = temp_dir.path().join("models");
-        let cache_dir = temp_dir.path().join("cache");
-        let audit_dir = temp_dir.path().join("audit");
-        let dashboard_data_dir = temp_dir.path().join("dashboard");
-        let response_cache_dir = temp_dir.path().join("response_cache");
-        let batch_storage_dir = temp_dir.path().join("batch_storage");
-
-        // Create directories
-        for dir in [
-            &models_dir,
-            &cache_dir,
-            &audit_dir,
-            &dashboard_data_dir,
-            &response_cache_dir,
-            &batch_storage_dir,
-        ] {
-            fs::create_dir_all(dir).await?;
-        }
-
-        // Create test model files
-        create_test_models(&models_dir).await?;
-
-        // Initialize components
-        let model_manager = Arc::new(ModelManager::new(models_dir.clone()));
-        let models = model_manager.discover_models().await?;
-
-        let metrics_collector = Arc::new(MetricsCollector::new());
-
-        let backend_config = BackendConfig {
-            gpu_enabled: false,
-            gpu_device: None,
-            cpu_threads: Some(2),
-            context_size: 512,
-            batch_size: 8,
-            memory_map: true,
-        };
-
-        let cache_config = CacheConfig {
-            max_cached_models: 3,
-            max_memory_mb: 1024,
-            model_ttl_seconds: 300,
-            enable_warmup: true,
-            warmup_strategy: WarmupStrategy::UsageBased,
-            always_warm: vec!["test_model_1".to_string()],
-            predictive_loading: false,
-            usage_window_seconds: 3600,
-            min_usage_frequency: 0.1,
-            memory_based_eviction: true,
-            persist_cache: true,
-            cache_dir: Some(cache_dir),
-        };
-
-        let model_cache = Arc::new(
-            ModelCache::new(
-                cache_config,
-                backend_config.clone(),
-                model_manager.clone(),
-                Some(metrics_collector.clone()),
-            )
-            .await?,
-        );
-
-        let audit_config = AuditConfig {
-            enabled: true,
-            log_directory: audit_dir,
-            max_file_size_mb: 10,
-            max_files: 5,
-            compression: inferno::audit::CompressionType::Zstd,
-            compression_level: 3,
-            encryption: inferno::audit::EncryptionConfig {
-                enabled: false, // Disable for testing
-                algorithm: "AES-256-GCM".to_string(),
-                key_derivation: "PBKDF2".to_string(),
-                key_rotation_days: 30,
-                master_key_path: None,
-            },
-            retention: inferno::audit::RetentionPolicy {
-                default_retention_days: 365,
-                critical_retention_days: 2555,
-                audit_log_retention_days: 2555,
-                compliance_retention_days: 2555,
-                max_storage_gb: 100,
-                auto_archive: true,
-                archive_compression: inferno::audit::CompressionType::Zstd,
-            },
-            compliance: inferno::audit::ComplianceConfig {
-                enable_sox: false,
-                enable_hipaa: false,
-                enable_gdpr: false,
-                enable_pci: false,
-                custom_requirements: HashMap::new(),
-            },
-            alerting: inferno::audit::AlertingConfig {
-                enabled: false, // Disable for testing
-                alert_directory: temp_dir.path().join("alerts"),
-                email_enabled: false,
-                webhook_enabled: false,
-                slack_enabled: false,
-                smtp_config: None,
-                webhook_urls: Vec::new(),
-                slack_config: None,
-                alert_cooldown_minutes: 5,
-                max_alerts_per_hour: 100,
-            },
-            buffer_size: 1000,
-            flush_interval_seconds: 2,
-            async_processing: true,
-            enable_metrics: true,
-            debug_mode: true,
-        };
-
-        let audit_system = Arc::new(AuditSystem::new(audit_config).await?);
-
-        let queue_config = JobQueueConfig {
-            max_queues: 10,
-            max_jobs_per_queue: 100,
-            default_timeout_minutes: 30,
-            max_retries: 3,
-            cleanup_interval_seconds: 60,
-            metrics_retention_hours: 24,
-            persistent_storage: true,
-            storage_path: Some(batch_storage_dir),
-            enable_metrics: true,
-            enable_deadletter_queue: true,
-            max_concurrent_jobs: 3,
-            job_timeout_seconds: 300,
-            retry_delay_seconds: 5,
-            max_retry_delay_seconds: 300,
-            exponential_backoff: true,
-        };
-
-        let job_queue_manager = Arc::new(JobQueueManager::new(queue_config));
-
-        let scheduler_config = SchedulerConfig {
-            enable_scheduler: true,
-            max_concurrent_schedules: 50,
-            schedule_check_interval_seconds: 5,
-            missed_schedule_tolerance_seconds: 30,
-            enable_schedule_persistence: false,
-            persistence_path: None,
-            timezone: "UTC".to_string(),
-            enable_metrics: true,
-            max_schedule_history: 100,
-        };
-
-        let batch_scheduler =
-            Arc::new(BatchScheduler::new(scheduler_config, job_queue_manager.clone()).await?);
-
-        let processor_config = ProcessorConfig {
-            max_concurrent_jobs: 2,
-            worker_pool_size: 2,
-            enable_batching: true,
-            batch_size: 5,
-            batch_timeout_seconds: 30,
-            enable_monitoring: true,
-            heartbeat_interval_seconds: 10,
-            failure_threshold: 3,
-            recovery_interval_seconds: 60,
-            enable_circuit_breaker: true,
-            circuit_breaker_threshold: 5,
-            circuit_breaker_timeout_seconds: 30,
-        };
-
-        let batch_processor = Arc::new(
-            BatchProcessor::new(
-                processor_config,
-                job_queue_manager.clone(),
-                model_cache.clone(),
-                Some(metrics_collector.clone()),
-            )
-            .await?,
-        );
-
-        let response_cache_config = ResponseCacheConfig {
-            enabled: true,
-            max_entries: 1000,
-            ttl_seconds: 3600,
-            max_memory_mb: 100,
-            compression_enabled: true,
-            compression_algorithm: "zstd".to_string(),
-            compression_level: 3,
-            persistence_enabled: true,
-            persistence_path: Some(response_cache_dir),
-            enable_metrics: true,
-        };
-
-        let response_cache = Arc::new(ResponseCache::new(response_cache_config).await?);
-
-        let dashboard_config = DashboardConfig {
-            bind_address: "127.0.0.1".to_string(),
-            port: 0,
-            data_dir: Some(dashboard_data_dir),
-            models_dir: Some(models_dir),
-            cache_dir: Some(temp_dir.path().join("cache")),
-            enable_auth: false,
-            cors_enabled: true,
-            max_connections: 100,
-            request_timeout_seconds: 30,
-            static_files_dir: None,
-            ssl_cert_path: None,
-            ssl_key_path: None,
-            api_keys: Vec::new(),
-            rate_limit_requests_per_minute: 1000,
-            backup_enabled: false,
-            backup_interval_hours: 24,
-            backup_retention_days: 7,
-        };
-
-        let dashboard_server = Arc::new(DashboardServer::new(dashboard_config).await?);
-
-        let model_converter = Arc::new(ModelConverter::new());
-
-        Ok(TestEnvironment {
-            model_manager,
-            model_cache,
-            metrics_collector,
-            audit_system,
-            job_queue_manager,
-            batch_scheduler,
-            batch_processor,
-            response_cache,
-            dashboard_server,
-            model_converter,
-            backend_config,
-            discovered_models: models,
-        })
-    }
-
-    pub async fn create_test_models(models_dir: &PathBuf) -> Result<()> {
-        let models = vec![
-            ("test_model_1.gguf", "Test Model 1"),
-            ("test_model_2.gguf", "Test Model 2"),
-            ("test_model_3.onnx", "Test Model 3"),
-        ];
-
-        for (filename, model_name) in models {
-            let path = models_dir.join(filename);
-
-            if filename.ends_with(".gguf") {
-                create_mock_gguf_file(&path, model_name)?;
-            } else if filename.ends_with(".onnx") {
-                create_mock_onnx_file(&path, model_name)?;
-            }
-        }
-
-        Ok(())
-    }
-
-    fn create_mock_gguf_file(path: &PathBuf, model_name: &str) -> Result<()> {
-        let mut content = Vec::new();
-        content.extend_from_slice(b"GGUF");
-        content.extend_from_slice(&3u32.to_le_bytes());
-        content.extend_from_slice(&0u64.to_le_bytes());
-        content.extend_from_slice(&1u64.to_le_bytes());
-
-        let key = "general.name";
-        content.extend_from_slice(&(key.len() as u64).to_le_bytes());
-        content.extend_from_slice(key.as_bytes());
-        content.extend_from_slice(&8u32.to_le_bytes());
-        content.extend_from_slice(&(model_name.len() as u64).to_le_bytes());
-        content.extend_from_slice(model_name.as_bytes());
-
-        content.resize(4096, 0);
-        std::fs::write(path, content)?;
-        Ok(())
-    }
-
-    fn create_mock_onnx_file(path: &PathBuf, model_name: &str) -> Result<()> {
-        let mut content = Vec::new();
-        content.extend_from_slice(&[0x08, 0x01]);
-        content.extend_from_slice(&[0x12, model_name.len() as u8]);
-        content.extend_from_slice(model_name.as_bytes());
-        content.resize(2048, 0);
-        std::fs::write(path, content)?;
-        Ok(())
-    }
-
-    pub fn create_test_batch_job(id: &str, model_name: &str) -> BatchJob {
-        BatchJob {
-            id: id.to_string(),
-            name: format!("Integration Test Job {}", id),
-            description: Some("Cross-component integration test job".to_string()),
-            priority: JobPriority::Normal,
-            inputs: vec![
-                BatchInput {
-                    id: format!("{}-input-1", id),
-                    content: "What is machine learning?".to_string(),
-                    metadata: Some(HashMap::from([(
-                        "type".to_string(),
-                        "question".to_string(),
-                    )])),
-                },
-                BatchInput {
-                    id: format!("{}-input-2", id),
-                    content: "Explain neural networks.".to_string(),
-                    metadata: Some(HashMap::from([(
-                        "type".to_string(),
-                        "explanation".to_string(),
-                    )])),
-                },
-            ],
-            inference_params: InferenceParams {
-                max_tokens: 100,
-                temperature: 0.7,
-                top_p: 0.9,
-                stream: false,
-                ..Default::default()
-            },
-            model_name: model_name.to_string(),
-            batch_config: BatchConfig {
-                batch_size: 10,
-                timeout_seconds: 300,
-                parallel_processing: true,
-                max_parallel_batches: 2,
-                enable_streaming: false,
-                output_format: "json".to_string(),
-                compression_enabled: false,
-                checkpointing_enabled: false,
-                checkpoint_interval_seconds: 60,
-            },
-            schedule: None,
-            dependencies: vec![],
-            resource_requirements: inferno::batch::queue::ResourceRequirements {
-                min_memory_mb: 256,
-                min_cpu_cores: 1,
-                min_gpu_memory_mb: None,
-                required_gpu: false,
-                estimated_duration_seconds: Some(60),
-                max_memory_mb: Some(1024),
-                max_cpu_cores: Some(2),
-            },
-            timeout_minutes: Some(10),
-            retry_count: 0,
-            max_retries: 2,
-            created_at: SystemTime::now(),
-            scheduled_at: None,
-            tags: HashMap::from([("integration_test".to_string(), "true".to_string())]),
-            metadata: HashMap::from([("test_run_id".to_string(), Uuid::new_v4().to_string())]),
-        }
+fn cpu_backend_config() -> BackendConfig {
+    BackendConfig {
+        gpu_enabled: false,
+        gpu_device: None,
+        cpu_threads: Some(2),
+        context_size: 512,
+        batch_size: 8,
+        memory_map: true,
     }
 }
 
-pub struct TestEnvironment {
-    pub model_manager: Arc<ModelManager>,
-    pub model_cache: Arc<ModelCache>,
-    pub metrics_collector: Arc<MetricsCollector>,
-    pub audit_system: Arc<AuditSystem>,
-    pub job_queue_manager: Arc<JobQueueManager>,
-    pub batch_scheduler: Arc<BatchScheduler>,
-    pub batch_processor: Arc<BatchProcessor>,
-    pub response_cache: Arc<ResponseCache>,
-    pub dashboard_server: Arc<DashboardServer>,
-    pub model_converter: Arc<ModelConverter>,
-    pub backend_config: BackendConfig,
-    pub discovered_models: Vec<ModelInfo>,
+fn write_mock_gguf(path: &PathBuf, model_name: &str) -> Result<()> {
+    let mut content = Vec::new();
+    content.extend_from_slice(b"GGUF");
+    content.extend_from_slice(&3u32.to_le_bytes());
+    content.extend_from_slice(&0u64.to_le_bytes());
+    content.extend_from_slice(&1u64.to_le_bytes());
+    let key = "general.name";
+    content.extend_from_slice(&(key.len() as u64).to_le_bytes());
+    content.extend_from_slice(key.as_bytes());
+    content.extend_from_slice(&8u32.to_le_bytes());
+    content.extend_from_slice(&(model_name.len() as u64).to_le_bytes());
+    content.extend_from_slice(model_name.as_bytes());
+    content.resize(4096, 0);
+    std::fs::write(path, content)?;
+    Ok(())
 }
 
-/// Test end-to-end model lifecycle across all components
-#[tokio::test]
-async fn test_end_to_end_model_lifecycle() -> Result<()> {
-    let temp_dir = TempDir::new()?;
-    let env = integration_test_utils::setup_complete_test_environment(&temp_dir).await?;
+/// Builds a full component environment. When `real_model` is true the models
+/// directory is populated with copies of `INFERNO_TEST_MODEL` (returning None
+/// if it is unset so the caller can skip); otherwise it is populated with mock
+/// GGUF files that are discoverable but not loadable.
+async fn build_env(real_model: bool) -> Result<Option<TestEnv>> {
+    let temp = TempDir::new()?;
+    let models_dir = temp.path().join("models");
+    std::fs::create_dir_all(&models_dir)?;
 
-    // Start all systems
-    env.audit_system.start().await?;
-    env.batch_scheduler.start().await?;
+    if real_model {
+        let Ok(src) = std::env::var("INFERNO_TEST_MODEL") else {
+            return Ok(None);
+        };
+        for name in ["model_a", "model_b"] {
+            std::fs::copy(&src, models_dir.join(format!("{name}.gguf")))?;
+        }
+    } else {
+        write_mock_gguf(&models_dir.join("test_model_1.gguf"), "Test Model 1")?;
+        write_mock_gguf(&models_dir.join("test_model_2.gguf"), "Test Model 2")?;
+    }
 
-    // 1. Model Discovery and Loading
-    assert!(
-        !env.discovered_models.is_empty(),
-        "Should discover test models"
-    );
+    let model_manager = Arc::new(ModelManager::new(&models_dir));
+    let models = model_manager.list_models().await?;
 
-    let test_model = &env.discovered_models[0];
+    let cache_config = CacheConfig {
+        max_cached_models: 3,
+        max_memory_mb: 4096,
+        model_ttl_seconds: 300,
+        memory_based_eviction: true,
+        ..Default::default()
+    };
+    let model_cache =
+        Arc::new(ModelCache::new(cache_config, cpu_backend_config(), model_manager, None).await?);
 
-    // Create audit event for model discovery
-    let discovery_event = AuditEvent {
+    let audit_config = AuditConfiguration {
+        enabled: true,
+        log_level: LogLevel::All,
+        storage_path: temp.path().join("audit"),
+        alert_on_critical: false,
+        batch_size: 20_000,
+        ..Default::default()
+    };
+    let audit = Arc::new(AuditLogger::new(audit_config).await?);
+
+    let queue = Arc::new(JobQueueManager::new(JobQueueConfig {
+        max_queue_size: 1000,
+        max_concurrent_jobs: 3,
+        ..Default::default()
+    }));
+
+    let response_cache_config = ResponseCacheConfig {
+        enabled: true,
+        max_entries: 1000,
+        ttl_seconds: 3600,
+        max_memory_mb: 100,
+        compression_enabled: false,
+        ..Default::default()
+    };
+    let response_cache = Arc::new(ResponseCache::new(response_cache_config, None).await?);
+
+    Ok(Some(TestEnv {
+        model_cache,
+        audit,
+        queue,
+        response_cache,
+        models,
+        _temp: temp,
+    }))
+}
+
+fn make_meta() -> ResponseMetadata {
+    ResponseMetadata {
+        model_id: "test_model".to_string(),
+        response_type: "text".to_string(),
+        token_count: None,
+        processing_time_ms: 0,
+        quality_score: None,
+        content_type: "text/plain".to_string(),
+    }
+}
+
+fn make_job(id: &str, model_name: &str) -> BatchJob {
+    BatchJob {
+        id: id.to_string(),
+        name: format!("Integration Test Job {id}"),
+        description: None,
+        priority: JobPriority::Normal,
+        inputs: vec![BatchInput {
+            id: format!("{id}-input"),
+            content: "What is machine learning?".to_string(),
+            metadata: None,
+        }],
+        inference_params: InferenceParams::default(),
+        model_name: model_name.to_string(),
+        batch_config: BatchConfig::default(),
+        schedule: None,
+        dependencies: vec![],
+        resource_requirements: ResourceRequirements::default(),
+        timeout_minutes: Some(10),
+        retry_count: 0,
+        max_retries: 2,
+        retry_config: RetryConfig::default(),
+        created_at: SystemTime::now(),
+        scheduled_at: None,
+        tags: HashMap::new(),
+        metadata: HashMap::new(),
+    }
+}
+
+/// Builds a fully-populated audit event. `actor_name` is used to isolate a
+/// test's events for exact-count queries.
+fn make_event(actor_id: &str, actor_name: &str, action: &str) -> AuditEvent {
+    AuditEvent {
         id: Uuid::new_v4().to_string(),
         timestamp: SystemTime::now(),
         event_type: EventType::ModelManagement,
         severity: Severity::Info,
         actor: Actor {
             actor_type: ActorType::System,
-            id: "model_manager".to_string(),
-            name: "Model Manager".to_string(),
+            id: actor_id.to_string(),
+            name: actor_name.to_string(),
             ip_address: None,
             user_agent: None,
             session_id: None,
         },
-        resource: inferno::audit::Resource {
-            resource_type: inferno::audit::ResourceType::Model,
-            id: test_model.id.clone(),
-            name: test_model.name.clone(),
-            path: Some(test_model.path.to_string_lossy().to_string()),
-            attributes: HashMap::new(),
+        resource: Resource {
+            resource_type: ResourceType::Model,
+            id: "model-resource".to_string(),
+            name: "model".to_string(),
+            path: None,
+            owner: None,
+            tags: vec![],
         },
-        action: "model_discovered".to_string(),
-        details: inferno::audit::EventDetails {
-            description: "Model discovered during integration test".to_string(),
-            request_id: Some(Uuid::new_v4().to_string()),
-            trace_id: None,
-            span_id: None,
+        action: action.to_string(),
+        details: EventDetails {
+            description: format!("cross-component test event: {action}"),
             parameters: HashMap::new(),
-            response_data: None,
-            error_details: None,
+            request_id: None,
+            correlation_id: None,
+            trace_id: None,
+            parent_event_id: None,
         },
-        context: inferno::audit::EventContext {
-            source_component: "integration_test".to_string(),
+        context: EventContext {
             environment: "test".to_string(),
+            application: "cross_component_test".to_string(),
             version: "1.0.0".to_string(),
-            region: None,
-            availability_zone: None,
-            cluster: None,
-            node: None,
-            tenant_id: None,
-            correlation_id: Some(Uuid::new_v4().to_string()),
+            hostname: "localhost".to_string(),
+            process_id: 0,
+            thread_id: None,
+            request_path: None,
+            request_method: None,
+            client_info: None,
         },
-        outcome: inferno::audit::EventOutcome {
+        outcome: EventOutcome {
             success: true,
             status_code: Some(200),
+            error_code: None,
+            error_message: None,
             duration_ms: Some(10),
-            bytes_processed: Some(test_model.size),
+            bytes_processed: None,
             records_affected: Some(1),
-            resource_usage: HashMap::new(),
         },
         metadata: HashMap::new(),
-    };
+    }
+}
 
-    env.audit_system.log_event(discovery_event).await?;
-
-    // 2. Model Loading via Cache
-    let backend_handle = env
-        .model_cache
-        .get_or_load_model(&test_model.id, BackendType::Gguf, &env.backend_config)
-        .await?;
-
-    assert!(backend_handle.is_loaded().await, "Model should be loaded");
-
-    // 3. Inference with Response Caching
-    let inference_params = InferenceParams {
-        max_tokens: 50,
-        temperature: 0.7,
-        top_p: 0.9,
-        stream: false,
+fn query_by_actor(actor_name: &str) -> AuditQuery {
+    AuditQuery {
+        actors: Some(vec![actor_name.to_string()]),
+        limit: Some(500),
         ..Default::default()
+    }
+}
+
+/// End-to-end model lifecycle: discover -> audit -> cache-load+infer ->
+/// response-cache roundtrip -> queue submit. Gated on `INFERNO_TEST_MODEL`.
+#[tokio::test]
+async fn test_end_to_end_model_lifecycle() -> Result<()> {
+    let Some(env) = build_env(true).await? else {
+        eprintln!("INFERNO_TEST_MODEL not set; skipping end-to-end lifecycle test");
+        return Ok(());
     };
 
-    let input = "What is artificial intelligence?";
-    let cache_key = CacheKey::new(&test_model.id, input, &inference_params);
+    assert!(!env.models.is_empty(), "should discover copied models");
+    let model = env.models[0].clone();
 
-    // First inference (cache miss)
-    let start_time = std::time::Instant::now();
-    let result1 = backend_handle.infer(input, &inference_params).await?;
-    let inference_time = start_time.elapsed();
-
-    // Store in response cache
-    env.response_cache
-        .store(&cache_key, &result1, Duration::from_secs(3600))
+    // 1. Audit the discovery through the real logger.
+    env.audit
+        .log_event(make_event(
+            "model_manager",
+            "lifecycle_actor",
+            "model_discovered",
+        ))
         .await?;
 
-    // Second inference (should hit cache)
-    let cached_result = env.response_cache.get(&cache_key).await?;
-    assert!(cached_result.is_some(), "Should get cached result");
+    // 2. Load the model through the cache and run inference.
+    let cached = env.model_cache.get_model(&model.name).await?;
+    let input = "What is artificial intelligence?";
+    let result = cached
+        .backend
+        .infer(input, &InferenceParams::default())
+        .await?;
+    assert!(!result.is_empty(), "inference should produce output");
+
+    // 3. Store the response and read it straight back.
+    let key = CacheKey::new(input, &model.name, "default", &HashAlgorithm::Sha256);
+    env.response_cache
+        .put(&key, result.clone().into_bytes(), make_meta())
+        .await?;
+    let cached_bytes = env.response_cache.get(&key).await;
     assert_eq!(
-        cached_result.unwrap(),
-        result1,
-        "Cached result should match"
+        cached_bytes,
+        Some(result.into_bytes()),
+        "cached response should match the inference output"
     );
 
-    // 4. Batch Job Processing
-    let queue_id = "integration-queue";
-    env.job_queue_manager
+    // 4. Submit a batch job describing the same model.
+    env.queue
         .create_queue(
-            queue_id.to_string(),
-            "Integration Test Queue".to_string(),
-            "Queue for cross-component testing".to_string(),
+            "lifecycle".to_string(),
+            "Lifecycle Queue".to_string(),
+            "Cross-component lifecycle test".to_string(),
         )
         .await?;
-
-    let batch_job =
-        integration_test_utils::create_test_batch_job("integration-job-1", &test_model.id);
-    env.job_queue_manager
-        .submit_job(queue_id, batch_job)
+    env.queue
+        .submit_job("lifecycle", make_job("lifecycle-job", &model.name))
         .await?;
+    let metrics = env
+        .queue
+        .get_queue_metrics("lifecycle")
+        .await
+        .expect("queue exists");
+    assert_eq!(metrics.total_jobs_submitted, 1);
 
-    // Start batch processor
-    let processor_handle = tokio::spawn({
-        let processor = env.batch_processor.clone();
-        async move { processor.start_processing().await }
-    });
+    // 5. The discovery event is queryable.
+    let events = env
+        .audit
+        .query_events(query_by_actor("lifecycle_actor"))
+        .await?;
+    assert_eq!(events.len(), 1, "the discovery event should be recorded");
+    assert_eq!(events[0].action, "model_discovered");
 
-    // Wait for job processing
-    sleep(Duration::from_secs(10)).await;
+    // 6. The cache registered the loaded model.
+    let stats = env.model_cache.get_stats().await;
+    assert!(
+        stats.total_models >= 1,
+        "cache should hold the loaded model"
+    );
 
-    // 5. Dashboard API Integration
-    let dashboard_router = env.dashboard_server.create_router().await?;
-
-    // Create model via API
-    let create_model_request = json!({
-        "name": "api_test_model",
-        "version": "v1.0",
-        "format": "GGUF",
-        "description": "Model created via API integration test",
-        "tags": ["integration", "test"]
-    });
-
-    let request = Request::builder()
-        .method(Method::POST)
-        .uri("/api/v1/models")
-        .header("Content-Type", "application/json")
-        .body(Body::from(create_model_request.to_string()))?;
-
-    let response = dashboard_router.clone().oneshot(request).await?;
-    assert_eq!(response.status(), StatusCode::CREATED);
-
-    // Get metrics via API
-    let request = Request::builder()
-        .method(Method::GET)
-        .uri("/api/v1/metrics")
-        .body(Body::empty())?;
-
-    let response = dashboard_router.oneshot(request).await?;
-    assert_eq!(response.status(), StatusCode::OK);
-
-    let body_bytes = to_bytes(response.into_body()).await?;
-    let metrics: Value = serde_json::from_slice(&body_bytes)?;
-    assert!(metrics.get("total_models").is_some());
-
-    // 6. Verify Audit Trail
-    env.audit_system.flush().await?;
-    sleep(Duration::from_secs(3)).await;
-
-    let audit_query = inferno::audit::AuditQuery {
-        filters: vec![inferno::audit::QueryFilter::EventType(
-            EventType::ModelManagement,
-        )],
-        start_time: Some(SystemTime::now() - Duration::from_secs(300)),
-        end_time: Some(SystemTime::now()),
-        limit: Some(100),
-        offset: None,
-        sort_by: None,
-        sort_order: None,
-    };
-
-    let audit_events = env.audit_system.query_events(audit_query).await?;
-    assert!(!audit_events.is_empty(), "Should have audit events");
-
-    // 7. Check Metrics Collection
-    let cache_stats = env.model_cache.get_stats().await;
-    assert!(cache_stats.cache_hits + cache_stats.cache_misses > 0);
-
-    let response_cache_stats = env.response_cache.get_stats().await?;
-    assert!(response_cache_stats.total_entries > 0);
-
-    // Cleanup
-    env.batch_processor.stop_processing().await?;
-    env.batch_scheduler.stop().await?;
-    env.audit_system.shutdown().await?;
-
-    let _ = timeout(Duration::from_secs(5), processor_handle).await;
-
+    env.audit.shutdown().await;
     Ok(())
 }
 
-/// Test system resilience and error propagation
+/// Resilience: failures in one component surface as errors without corrupting
+/// the others. Model-free (the model load targets a nonexistent name).
 #[tokio::test]
 async fn test_system_resilience_and_error_handling() -> Result<()> {
-    let temp_dir = TempDir::new()?;
-    let env = integration_test_utils::setup_complete_test_environment(&temp_dir).await?;
+    let env = build_env(false).await?.expect("mock env always builds");
 
-    env.audit_system.start().await?;
-
-    // Test 1: Model loading failure cascade
-    let nonexistent_model_id = "nonexistent_model";
-    let load_result = env
-        .model_cache
-        .get_or_load_model(nonexistent_model_id, BackendType::Gguf, &env.backend_config)
-        .await;
-
+    // Loading a model that does not exist fails cleanly.
+    let load_result = env.model_cache.get_model("nonexistent_model").await;
     assert!(
         load_result.is_err(),
-        "Should fail to load nonexistent model"
+        "loading a nonexistent model should fail"
     );
 
-    // Test 2: Batch job with invalid model
-    let queue_id = "error-test-queue";
-    env.job_queue_manager
+    // A job naming an invalid model is still accepted by the queue (the queue
+    // does not validate model existence) and sits in the Queued state.
+    env.queue
         .create_queue(
-            queue_id.to_string(),
-            "Error Test Queue".to_string(),
-            "Queue for testing error handling".to_string(),
+            "error".to_string(),
+            "Error Queue".to_string(),
+            "Error handling test".to_string(),
         )
         .await?;
-
-    let invalid_job =
-        integration_test_utils::create_test_batch_job("error-job", "nonexistent_model");
-    env.job_queue_manager
-        .submit_job(queue_id, invalid_job)
+    env.queue
+        .submit_job("error", make_job("error-job", "nonexistent_model"))
         .await?;
-
-    // Start processor to handle the failing job
-    let processor_handle = tokio::spawn({
-        let processor = env.batch_processor.clone();
-        async move { processor.start_processing().await }
-    });
-
-    sleep(Duration::from_secs(5)).await;
-
-    // Check job status - should be failed or in retry
-    let job_status = env
-        .job_queue_manager
-        .get_job_status(queue_id, "error-job")
-        .await?;
-    assert!(job_status.is_some());
-
-    let job_info = job_status.unwrap();
+    let status = env.queue.get_job_status("error", "error-job").await?;
+    let job_info = status.expect("submitted job should have a status");
     assert!(
-        matches!(job_info.status, JobStatus::Failed | JobStatus::Queued),
-        "Job should be failed or queued for retry"
+        matches!(job_info.status, JobStatus::Queued),
+        "an unprocessed job should be queued"
     );
 
-    // Test 3: Response cache with corrupted data
-    let cache_key = CacheKey::new("test_model", "test input", &InferenceParams::default());
+    // A miss on the response cache returns None rather than erroring.
+    let miss_key = CacheKey::new("absent", "test_model", "default", &HashAlgorithm::Sha256);
+    assert!(
+        env.response_cache.get(&miss_key).await.is_none(),
+        "an empty cache should return None"
+    );
 
-    // Try to get from empty cache
-    let empty_result = env.response_cache.get(&cache_key).await?;
-    assert!(empty_result.is_none(), "Should get None from empty cache");
-
-    // Test 4: Dashboard API error handling
-    let dashboard_router = env.dashboard_server.create_router().await?;
-
-    // Invalid JSON request
-    let request = Request::builder()
-        .method(Method::POST)
-        .uri("/api/v1/models")
-        .header("Content-Type", "application/json")
-        .body(Body::from("invalid json"))?;
-
-    let response = dashboard_router.clone().oneshot(request).await?;
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-
-    // Non-existent resource
-    let request = Request::builder()
-        .method(Method::GET)
-        .uri("/api/v1/models/nonexistent")
-        .body(Body::empty())?;
-
-    let response = dashboard_router.oneshot(request).await?;
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
-
-    // Test 5: Verify error events in audit log
-    env.audit_system.flush().await?;
-    sleep(Duration::from_secs(2)).await;
-
-    let error_query = inferno::audit::AuditQuery {
-        filters: vec![inferno::audit::QueryFilter::Severity(Severity::High)],
-        start_time: Some(SystemTime::now() - Duration::from_secs(300)),
-        end_time: Some(SystemTime::now()),
-        limit: Some(100),
-        offset: None,
-        sort_by: None,
-        sort_order: None,
-    };
-
-    let error_events = env.audit_system.query_events(error_query).await?;
-    // May or may not have error events depending on audit integration
-
-    // Cleanup
-    env.batch_processor.stop_processing().await?;
-    env.audit_system.shutdown().await?;
-    let _ = timeout(Duration::from_secs(5), processor_handle).await;
-
+    env.audit.shutdown().await;
     Ok(())
 }
 
-/// Test concurrent operations across components
+/// Concurrent operations across the response cache, job queue, and audit log.
+/// Model-free. Exact counts are asserted after all tasks join.
 #[tokio::test]
 async fn test_concurrent_cross_component_operations() -> Result<()> {
-    let temp_dir = TempDir::new()?;
-    let env = integration_test_utils::setup_complete_test_environment(&temp_dir).await?;
+    let env = build_env(false).await?.expect("mock env always builds");
 
-    env.audit_system.start().await?;
-    env.batch_scheduler.start().await?;
-
-    let queue_id = "concurrent-queue";
-    env.job_queue_manager
+    env.queue
         .create_queue(
-            queue_id.to_string(),
-            "Concurrent Test Queue".to_string(),
-            "Queue for concurrent testing".to_string(),
+            "concurrent".to_string(),
+            "Concurrent Queue".to_string(),
+            "Concurrent cross-component test".to_string(),
         )
         .await?;
 
-    // Start batch processor
-    let processor_handle = tokio::spawn({
-        let processor = env.batch_processor.clone();
-        async move { processor.start_processing().await }
-    });
+    let mut handles = Vec::new();
 
-    // Launch concurrent operations
-    let mut tasks = Vec::new();
-
-    // Task 1: Concurrent model loading
-    for i in 0..3 {
-        let cache = env.model_cache.clone();
-        let backend_config = env.backend_config.clone();
-        let model_id = env.discovered_models[i % env.discovered_models.len()]
-            .id
-            .clone();
-
-        let task = tokio::spawn(async move {
-            for _ in 0..5 {
-                let result = cache
-                    .get_or_load_model(&model_id, BackendType::Gguf, &backend_config)
-                    .await;
-                if let Ok(handle) = result {
-                    let _ = handle
-                        .infer("Test concurrent inference", &InferenceParams::default())
-                        .await;
-                }
-                sleep(Duration::from_millis(100)).await;
-            }
-        });
-        tasks.push(task);
-    }
-
-    // Task 2: Concurrent batch job submission
-    for i in 0..5 {
-        let queue_manager = env.job_queue_manager.clone();
-        let model_id = env.discovered_models[0].id.clone();
-
-        let task = tokio::spawn(async move {
-            let job = integration_test_utils::create_test_batch_job(
-                &format!("concurrent-job-{}", i),
-                &model_id,
-            );
-            let _ = queue_manager.submit_job("concurrent-queue", job).await;
-        });
-        tasks.push(task);
-    }
-
-    // Task 3: Concurrent response caching
+    // Concurrent response caching: 3 tasks x 5 store+read.
     for i in 0..3 {
         let response_cache = env.response_cache.clone();
-
-        let task = tokio::spawn(async move {
+        handles.push(tokio::spawn(async move {
             for j in 0..5 {
                 let key = CacheKey::new(
+                    &format!("concurrent_input_{i}_{j}"),
                     "test_model",
-                    &format!("concurrent input {} {}", i, j),
-                    &InferenceParams::default(),
+                    "default",
+                    &HashAlgorithm::Sha256,
                 );
-                let value = format!("response {} {}", i, j);
-
                 let _ = response_cache
-                    .store(&key, &value, Duration::from_secs(300))
+                    .put(&key, format!("response {i}:{j}").into_bytes(), make_meta())
                     .await;
                 let _ = response_cache.get(&key).await;
             }
-        });
-        tasks.push(task);
+        }));
     }
 
-    // Task 4: Concurrent audit logging
+    // Concurrent job submission: 5 jobs.
+    for i in 0..5 {
+        let queue = env.queue.clone();
+        handles.push(tokio::spawn(async move {
+            let _ = queue
+                .submit_job(
+                    "concurrent",
+                    make_job(&format!("concurrent-job-{i}"), "test_model"),
+                )
+                .await;
+        }));
+    }
+
+    // Concurrent audit logging: 3 tasks x 10 events, isolated by actor name.
     for i in 0..3 {
-        let audit_system = env.audit_system.clone();
-
-        let task = tokio::spawn(async move {
+        let audit = env.audit.clone();
+        handles.push(tokio::spawn(async move {
             for j in 0..10 {
-                let event = AuditEvent {
-                    id: Uuid::new_v4().to_string(),
-                    timestamp: SystemTime::now(),
-                    event_type: EventType::UserAction,
-                    severity: Severity::Info,
-                    actor: Actor {
-                        actor_type: ActorType::User,
-                        id: format!("user_{}", i),
-                        name: format!("User {}", i),
-                        ip_address: Some("127.0.0.1".to_string()),
-                        user_agent: None,
-                        session_id: None,
-                    },
-                    resource: inferno::audit::Resource {
-                        resource_type: inferno::audit::ResourceType::Api,
-                        id: format!("resource_{}_{}", i, j),
-                        name: format!("Resource {} {}", i, j),
-                        path: None,
-                        attributes: HashMap::new(),
-                    },
-                    action: "concurrent_action".to_string(),
-                    details: inferno::audit::EventDetails {
-                        description: format!("Concurrent action {} {}", i, j),
-                        request_id: Some(Uuid::new_v4().to_string()),
-                        trace_id: None,
-                        span_id: None,
-                        parameters: HashMap::new(),
-                        response_data: None,
-                        error_details: None,
-                    },
-                    context: inferno::audit::EventContext {
-                        source_component: "concurrent_test".to_string(),
-                        environment: "test".to_string(),
-                        version: "1.0.0".to_string(),
-                        region: None,
-                        availability_zone: None,
-                        cluster: None,
-                        node: None,
-                        tenant_id: None,
-                        correlation_id: None,
-                    },
-                    outcome: inferno::audit::EventOutcome {
-                        success: true,
-                        status_code: Some(200),
-                        duration_ms: Some(50),
-                        bytes_processed: Some(100),
-                        records_affected: Some(1),
-                        resource_usage: HashMap::new(),
-                    },
-                    metadata: HashMap::new(),
-                };
-
-                let _ = audit_system.log_event(event).await;
+                let _ = audit
+                    .log_event(make_event(
+                        &format!("user_{i}"),
+                        "concurrent_actor",
+                        &format!("concurrent_action_{j}"),
+                    ))
+                    .await;
             }
-        });
-        tasks.push(task);
+        }));
     }
 
-    // Wait for all concurrent operations
-    futures::future::join_all(tasks).await;
+    for h in handles {
+        h.await.unwrap();
+    }
 
-    // Wait for processing to complete
-    sleep(Duration::from_secs(10)).await;
-
-    // Verify system state after concurrent operations
-    let cache_stats = env.model_cache.get_stats().await;
-    assert!(cache_stats.cache_hits + cache_stats.cache_misses > 0);
-
-    let queue_metrics = env.job_queue_manager.get_queue_metrics(queue_id).await;
-    assert!(queue_metrics.is_some());
-
-    let response_cache_stats = env.response_cache.get_stats().await?;
-    assert!(response_cache_stats.total_entries > 0);
-
-    // Check audit events
-    env.audit_system.flush().await?;
-    sleep(Duration::from_secs(2)).await;
-
-    let audit_query = inferno::audit::AuditQuery {
-        filters: vec![inferno::audit::QueryFilter::Action(
-            "concurrent_action".to_string(),
-        )],
-        start_time: Some(SystemTime::now() - Duration::from_secs(300)),
-        end_time: Some(SystemTime::now()),
-        limit: Some(100),
-        offset: None,
-        sort_by: None,
-        sort_order: None,
-    };
-
-    let concurrent_events = env.audit_system.query_events(audit_query).await?;
+    // Exactly 30 audit events carry the concurrent actor.
+    let events = env
+        .audit
+        .query_events(query_by_actor("concurrent_actor"))
+        .await?;
     assert_eq!(
-        concurrent_events.len(),
+        events.len(),
         30,
-        "Should have 30 concurrent audit events (3 tasks * 10 events)"
+        "should record 30 concurrent audit events (3 tasks * 10)"
     );
 
-    // Cleanup
-    env.batch_processor.stop_processing().await?;
-    env.batch_scheduler.stop().await?;
-    env.audit_system.shutdown().await?;
-    let _ = timeout(Duration::from_secs(5), processor_handle).await;
+    // All 5 job submissions were counted.
+    let metrics = env
+        .queue
+        .get_queue_metrics("concurrent")
+        .await
+        .expect("queue exists");
+    assert_eq!(metrics.total_jobs_submitted, 5);
 
+    // The response cache holds the stored entries.
+    let cache_stats = env.response_cache.get_stats().await;
+    assert!(
+        cache_stats.total_entries > 0,
+        "response cache should hold entries"
+    );
+
+    env.audit.shutdown().await;
     Ok(())
 }
 
-/// Test data flow and consistency across components
+/// Data-flow consistency: a loaded model is visible in the cache, inference
+/// output roundtrips through the response cache, and hits are counted. Gated
+/// on `INFERNO_TEST_MODEL`.
 #[tokio::test]
 async fn test_data_flow_consistency() -> Result<()> {
-    let temp_dir = TempDir::new()?;
-    let env = integration_test_utils::setup_complete_test_environment(&temp_dir).await?;
+    let Some(env) = build_env(true).await? else {
+        eprintln!("INFERNO_TEST_MODEL not set; skipping data-flow consistency test");
+        return Ok(());
+    };
 
-    env.audit_system.start().await?;
+    let model = env.models[0].clone();
 
-    // Test data consistency between model discovery and cache
-    let discovered_models = &env.discovered_models;
-    assert!(!discovered_models.is_empty());
-
-    // Load a model and verify it appears in cache
-    let test_model = &discovered_models[0];
-    let backend_handle = env
-        .model_cache
-        .get_or_load_model(&test_model.id, BackendType::Gguf, &env.backend_config)
-        .await?;
-
-    let cached_models = env.model_cache.list_cached_models().await;
+    // A loaded model appears in the cache's active set.
+    let cached = env.model_cache.get_model(&model.name).await?;
+    let stats = env.model_cache.get_stats().await;
     assert!(
-        cached_models.contains(&test_model.id),
-        "Model should appear in cache list"
+        stats.active_models.contains(&model.name),
+        "loaded model should appear in active_models"
     );
 
-    // Test inference consistency
-    let input1 = "What is the meaning of life?";
+    // Inference produces output.
+    let input = "What is the meaning of life?";
     let params = InferenceParams::default();
+    let result = cached.backend.infer(input, &params).await?;
+    assert!(!result.is_empty());
 
-    let result1 = backend_handle.infer(input1, &params).await?;
-    let result2 = backend_handle.infer(input1, &params).await?;
-
-    // Results should be consistent (or at least both successful)
-    assert!(!result1.is_empty());
-    assert!(!result2.is_empty());
-
-    // Test response cache consistency
-    let cache_key = CacheKey::new(&test_model.id, input1, &params);
+    // Response-cache roundtrip is byte-consistent.
+    let key = CacheKey::new(input, &model.name, "default", &HashAlgorithm::Sha256);
     env.response_cache
-        .store(&cache_key, &result1, Duration::from_secs(3600))
+        .put(&key, result.clone().into_bytes(), make_meta())
         .await?;
-
-    let cached_result = env.response_cache.get(&cache_key).await?;
     assert_eq!(
-        cached_result.unwrap(),
-        result1,
-        "Cached result should match original"
+        env.response_cache.get(&key).await,
+        Some(result.into_bytes())
     );
 
-    // Test metrics consistency
-    let cache_stats_before = env.model_cache.get_stats().await;
-    let response_cache_stats_before = env.response_cache.get_stats().await?;
-
-    // Perform additional operations
-    let _ = backend_handle.infer("Another test input", &params).await?;
-    let _ = env.response_cache.get(&cache_key).await?; // Should be a hit
-
-    let cache_stats_after = env.model_cache.get_stats().await;
-    let response_cache_stats_after = env.response_cache.get_stats().await?;
-
-    // Verify metrics were updated
-    assert!(cache_stats_after.cache_hits >= cache_stats_before.cache_hits);
-    assert!(response_cache_stats_after.hits > response_cache_stats_before.hits);
-
-    // Test audit trail consistency
-    let discovery_audit_event = AuditEvent {
-        id: Uuid::new_v4().to_string(),
-        timestamp: SystemTime::now(),
-        event_type: EventType::ModelManagement,
-        severity: Severity::Info,
-        actor: Actor {
-            actor_type: ActorType::System,
-            id: "consistency_test".to_string(),
-            name: "Consistency Test".to_string(),
-            ip_address: None,
-            user_agent: None,
-            session_id: None,
-        },
-        resource: inferno::audit::Resource {
-            resource_type: inferno::audit::ResourceType::Model,
-            id: test_model.id.clone(),
-            name: test_model.name.clone(),
-            path: Some(test_model.path.to_string_lossy().to_string()),
-            attributes: HashMap::new(),
-        },
-        action: "consistency_check".to_string(),
-        details: inferno::audit::EventDetails {
-            description: "Data consistency verification".to_string(),
-            request_id: Some(Uuid::new_v4().to_string()),
-            trace_id: None,
-            span_id: None,
-            parameters: HashMap::new(),
-            response_data: None,
-            error_details: None,
-        },
-        context: inferno::audit::EventContext {
-            source_component: "consistency_test".to_string(),
-            environment: "test".to_string(),
-            version: "1.0.0".to_string(),
-            region: None,
-            availability_zone: None,
-            cluster: None,
-            node: None,
-            tenant_id: None,
-            correlation_id: None,
-        },
-        outcome: inferno::audit::EventOutcome {
-            success: true,
-            status_code: Some(200),
-            duration_ms: Some(10),
-            bytes_processed: Some(1024),
-            records_affected: Some(1),
-            resource_usage: HashMap::new(),
-        },
-        metadata: HashMap::from([
-            (
-                "cache_hits".to_string(),
-                serde_json::Value::Number(cache_stats_after.cache_hits.into()),
-            ),
-            (
-                "cached_models".to_string(),
-                serde_json::Value::Number(cache_stats_after.cached_models.into()),
-            ),
-        ]),
-    };
-
-    env.audit_system.log_event(discovery_audit_event).await?;
-    env.audit_system.flush().await?;
-    sleep(Duration::from_secs(2)).await;
-
-    // Verify audit event was recorded
-    let audit_query = inferno::audit::AuditQuery {
-        filters: vec![inferno::audit::QueryFilter::Action(
-            "consistency_check".to_string(),
-        )],
-        start_time: Some(SystemTime::now() - Duration::from_secs(60)),
-        end_time: Some(SystemTime::now()),
-        limit: Some(10),
-        offset: None,
-        sort_by: None,
-        sort_order: None,
-    };
-
-    let audit_results = env.audit_system.query_events(audit_query).await?;
-    assert_eq!(
-        audit_results.len(),
-        1,
-        "Should find consistency check audit event"
+    // A subsequent get is a counted hit.
+    let hits_before = env.response_cache.get_stats().await.cache_hits;
+    let _ = env.response_cache.get(&key).await;
+    let hits_after = env.response_cache.get_stats().await.cache_hits;
+    assert!(
+        hits_after > hits_before,
+        "a repeat read should register a hit"
     );
 
-    let recorded_event = &audit_results[0];
-    assert_eq!(recorded_event.action, "consistency_check");
-    assert_eq!(recorded_event.resource.id, test_model.id);
+    // Audit the consistency check and read exactly that event back.
+    env.audit
+        .log_event(make_event(
+            "consistency",
+            "consistency_actor",
+            "consistency_check",
+        ))
+        .await?;
+    let events = env
+        .audit
+        .query_events(query_by_actor("consistency_actor"))
+        .await?;
+    assert_eq!(events.len(), 1, "should find the consistency check event");
+    assert_eq!(events[0].action, "consistency_check");
 
-    env.audit_system.shutdown().await?;
-
+    env.audit.shutdown().await;
     Ok(())
 }


### PR DESCRIPTION
Part of the integration-test repair effort (#33). This suite failed to compile with 164 errors under \`--features gguf,onnx\` because it was written against an imagined API (\`AuditSystem\`, an \`AuditQuery { filters: Vec<QueryFilter> }\`, a \`JobQueueManager\`-fed \`BatchProcessor\`, \`BatchScheduler\`, \`DashboardServer::create_router\`, \`ModelInfo.id\`, \`CacheStats.cache_hits\`, \`ModelCache::get_or_load_model\`, \`ResponseCache::store\`, and many phantom config fields).

## Rewrite

Four tests wire the real components together. Two are model-free and run everywhere:

- **resilience / error handling** - loading a nonexistent model fails cleanly, a job naming an invalid model is still accepted by the queue and sits Queued, and an empty response-cache read returns \`None\`.
- **concurrent operations** across the response cache, job queue, and audit log - asserts exactly 30 audit events (isolated by a unique actor so the count is exact) and the exact submitted-job count after all tasks join.

Two load and run a model and are gated on \`INFERNO_TEST_MODEL\` (skipped when unset):

- **end-to-end lifecycle** - discover -> audit -> cache-load + infer -> response-cache byte-exact roundtrip -> queue submit -> exact audit query.
- **data-flow consistency** - a loaded model is visible in \`active_models\`, inference output roundtrips through the response cache, and a repeat read registers a counted hit.

## What was dropped and why

- **Dashboard HTTP-router portions** - \`DashboardServer\` has no \`create_router\`; the dashboard API tests are tracked separately (#44), so cross-component no longer depends on them.
- **The fictional queue-draining \`BatchProcessor\` / \`BatchScheduler\`** - that orchestration does not exist. Batch coverage is the real queue submit + \`get_job_status\` + queue-metrics path.

Audit queries use the real \`AuditQuery\` (\`event_types\`/\`severities\`/\`actors\`), and a large \`batch_size\` keeps the query buffer from draining mid-run so exact counts hold (same technique as #52).

## Verification

- \`cargo test --features gguf,onnx --test cross_component_integration_tests\`: 4 passed, gated tests skip cleanly without the env var.
- With \`INFERNO_TEST_MODEL\` set to a real tiny GGUF: 4 passed, including gated Metal inference and the response-cache roundtrips.
- Mutation-checked the concurrent count: logging 11 events per task instead of 10 makes the exact assertion fail (\`left: 33, right: 30\`), proving the actor-isolated query counts exactly the logged events with no drops or cross-actor leakage.
- \`cargo fmt --check\` clean; \`cargo clippy --features gguf,onnx --tests -- -D warnings\` clean.