### PR TITLE
chore(build): curb target/ disk growth from dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,6 +237,10 @@ strip = true
 
 [profile.dev]
 opt-level = 1
+# Line tables keep backtraces and file:line info for debugging while dropping the
+# bulky type/variable debuginfo that full `debug = 2` emits for large C/C++ deps
+# (llama-cpp, onnxruntime, tauri). Substantially smaller target/debug artifacts.
+debug = "line-tables-only"
 
 [[bench]]
 name = "inference_benchmark"

--- a/verify.sh
+++ b/verify.sh
@@ -16,6 +16,13 @@ NC='\033[0m' # No Color
 # Track overall status
 FAILED_CHECKS=0
 
+# verify.sh rebuilds the whole graph across several feature sets and every
+# integration-test binary. Incremental compilation caches almost nothing reusable
+# across such a full sweep but its on-disk cache can grow to tens of GB. Disable it
+# here so a full verification run does not balloon target/. Iterative `cargo check`
+# during development is unaffected (it does not source this script).
+export CARGO_INCREMENTAL=0
+
 echo -e "${BLUE}🔥 Inferno Verification Script${NC}"
 echo -e "${BLUE}================================${NC}\n"
 


### PR DESCRIPTION
Local `target/` had grown to ~90 GB (filling the disk to 100%), dominated by a 60 GB incremental-compilation cache plus stale, debuginfo-heavy dependency artifacts. A `cargo clean` reclaimed it; these two conservative changes keep it from ballooning again without giving up debuggability.

## Changes
- **`[profile.dev]` -> `debug = "line-tables-only"`**: keeps backtraces and `file:line` info for debugging while dropping the bulky type/variable debuginfo that the default `debug = 2` emits for large C/C++ dependencies (llama-cpp, onnxruntime, tauri). Substantially smaller `target/debug` artifacts.
- **`verify.sh` -> `export CARGO_INCREMENTAL=0`**: a full verification run rebuilds the whole graph across several feature sets and every integration-test binary. Incremental caches almost nothing reusable across such a sweep but its on-disk cache is what grew to tens of GB. Iterative `cargo check` during development does not source this script and is unaffected.

## Verification
- `cargo metadata` parses the manifest with the new profile.
- `bash -n verify.sh` passes.
- `cargo build --lib` succeeds under the new profile (cold build, 1m56s); a full default-feature lib build now lands `target/debug` at ~2.4 GB.

No application data or behavior is affected - these only change build-artifact size and debuginfo granularity.