### PR TITLE
feat(resilience): apply retry policy to HuggingFace model search

### DIFF
--- a/src/cli/models.rs
+++ b/src/cli/models.rs
@@ -1,5 +1,6 @@
 use crate::config::Config;
 use crate::models::ModelManager;
+use crate::resilience::{RetryConfig, RetryPolicy};
 use anyhow::Result;
 use clap::{Args, Subcommand};
 use std::path::PathBuf;
@@ -421,25 +422,36 @@ async fn search_huggingface(
         .user_agent("inferno/1.0")
         .build()?;
 
-    let mut req = client
-        .get("https://huggingface.co/api/models")
-        .query(&[
-            ("search", query),
-            ("sort", "downloads"),
-            ("direction", "-1"),
-        ])
-        .query(&[("limit", &limit.to_string())]);
+    // The HuggingFace API is an external network dependency, so wrap the fetch in
+    // a retry policy with exponential backoff and jitter to ride out transient
+    // failures. Response parsing below is deterministic and stays outside the retry.
+    let limit_str = limit.to_string();
+    let retry = RetryPolicy::new(RetryConfig::default());
+    let raw: serde_json::Value = retry
+        .execute(|| async {
+            let mut req = client
+                .get("https://huggingface.co/api/models")
+                .query(&[
+                    ("search", query),
+                    ("sort", "downloads"),
+                    ("direction", "-1"),
+                ])
+                .query(&[("limit", limit_str.as_str())]);
 
-    if let Some(t) = task {
-        req = req.query(&[("pipeline_tag", t)]);
-    }
+            if let Some(t) = task {
+                req = req.query(&[("pipeline_tag", t)]);
+            }
 
-    let resp = req.send().await?;
-    if !resp.status().is_success() {
-        anyhow::bail!("HuggingFace API returned {}", resp.status());
-    }
+            let resp = req.send().await?;
+            if !resp.status().is_success() {
+                anyhow::bail!("HuggingFace API returned {}", resp.status());
+            }
 
-    let raw: serde_json::Value = resp.json().await?;
+            let raw: serde_json::Value = resp.json().await?;
+            Ok(raw)
+        })
+        .await?;
+
     let arr = raw
         .as_array()
         .ok_or_else(|| anyhow::anyhow!("Unexpected API response format"))?;

--- a/src/resilience.rs
+++ b/src/resilience.rs
@@ -850,3 +850,59 @@ impl GracefulShutdown {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // Fast config so tests do not sleep on the default 1s+ backoff.
+    fn fast_retry_config(max_attempts: usize) -> RetryConfig {
+        RetryConfig {
+            max_attempts,
+            initial_delay_ms: 1,
+            max_delay_ms: 5,
+            backoff_multiplier: 2.0,
+            jitter_enabled: false,
+            retry_on_timeout: true,
+        }
+    }
+
+    #[tokio::test]
+    async fn retry_succeeds_after_transient_failures() {
+        let attempts = AtomicUsize::new(0);
+        let policy = RetryPolicy::new(fast_retry_config(3));
+
+        let result: Result<&str> = policy
+            .execute(|| async {
+                let n = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+                if n < 3 {
+                    Err(anyhow!("transient failure on attempt {n}"))
+                } else {
+                    Ok("ok")
+                }
+            })
+            .await;
+
+        assert_eq!(result.unwrap(), "ok");
+        // Failed twice, succeeded on the third attempt.
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn retry_exhausts_attempts_and_returns_last_error() {
+        let attempts = AtomicUsize::new(0);
+        let policy = RetryPolicy::new(fast_retry_config(3));
+
+        let result: Result<()> = policy
+            .execute(|| async {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                Err(anyhow!("always fails"))
+            })
+            .await;
+
+        assert!(result.is_err());
+        // Exactly max_attempts calls, no more.
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+}


### PR DESCRIPTION
Part of the #44 enterprise-module triage. Verdict for `resilience`: **promote (wire it in)** - minimal, safe scope.

## Context
`resilience` (circuit-breaker, retry, bulkhead, health monitor, graceful shutdown) was solid code that nothing in the runtime path actually called - only its own CLI + an `operations` re-export. Investigation showed the obvious target (the model downloader) has resume-state + a custom error type that don't fit the generic `Fn`-closure `RetryPolicy` without a refactor, and the other candidate (`marketplace`) is itself a later triage candidate. The clean, low-risk fit is the stateless HuggingFace API fetch.

## Changes
- **`inferno models search`**: the HuggingFace API fetch in `search_huggingface` is now wrapped in `resilience::RetryPolicy` (exponential backoff + jitter). Deterministic response parsing stays outside the retry. This is a genuine external-network dependency where retry-on-transient-failure is unambiguously correct.
- **`resilience` gains its first unit tests** (it had none): `retry_succeeds_after_transient_failures` (fails twice, succeeds on the third attempt) and `retry_exhausts_attempts_and_returns_last_error` (exactly `max_attempts` calls, returns the last error). Both use a fast config so they don't sleep on the default backoff.

## Not in scope (deliberately)
- The downloader's and `audit`'s own bespoke retry loops carry resume/state semantics that don't fit the generic policy - left as-is.
- `marketplace`'s registry client was skipped since `marketplace` is itself pending triage.
- The `resilience` module and its `inferno resilience` CLI are retained.

## Verification
- `cargo clippy --all-targets --features gguf,onnx -- -D warnings` - clean
- `cargo test --lib resilience::tests` - 2/2 pass
- **Mutation-checked**: crippling the retry loop to a single attempt (`1..=1`) makes both new tests fail; reverting restores green. The tests genuinely exercise retry behavior.