### PR TITLE
fix(cli): repair enhanced_parser fuzzy-matcher test broken by #62 vocab prune

### DIFF
--- a/src/cli/enhanced_parser.rs
+++ b/src/cli/enhanced_parser.rs
@@ -457,8 +457,14 @@ mod tests {
     #[test]
     fn test_enhanced_parser_creation() {
         let parser = EnhancedCliParser::new();
-        // Just test that it can be created without panicking
-        assert!(!parser.fuzzy_matcher.suggest_command("test").is_none());
+        // A freshly built parser carries a working fuzzy matcher: an obvious
+        // typo of a real command resolves to it. (The previous assertion keyed
+        // on "test" matching the top-level "list" command, which #62 removed
+        // with the marketplace surface, so it silently began returning None.)
+        assert_eq!(
+            parser.fuzzy_matcher.suggest_command("modelz"),
+            Some("models".to_string())
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem
`cli::enhanced_parser::tests::test_enhanced_parser_creation` fails on `main`. It asserted `suggest_command("test")` returns `Some` - which only ever held because `"test"` is Levenshtein distance 2 from the top-level `"list"` command. #62 removed `"list"` from the fuzzy vocab along with the marketplace/package-manager surface, and rewrote the `fuzzy.rs` unit tests, but missed this one in `enhanced_parser.rs`. It has been silently red since.

## Fix
`inferno` has no `test` command, so the assertion was incidental to the test's stated intent ("created without panicking"). Replace it with a stable, meaningful check: an obvious typo of a core command (`"modelz"`) resolves to it (`"models"`).

## Verification
- `cargo test --lib`: **698 pass, 0 fail** (was 697 pass / 1 fail on `main`).
- **Mutation-checked**: dropping `"models"` from the fuzzy vocab fails exactly this test (`None` vs `Some("models")`), no collateral.
- Clippy clean under `-D warnings` (lib, `gguf,onnx`).