### PR TITLE
security: resolve cargo audit advisories (#32)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -8,4 +8,16 @@ ignore = [
     # algorithms, so the vulnerable code path is not exercised. Revisit if a
     # fixed rsa release ships or if RSA JWT support is ever added.
     "RUSTSEC-2023-0071",
+
+    # quick-xml DoS advisories (quadratic duplicate-attribute scan / unbounded
+    # namespace-declaration allocation). No fix path is available: the only
+    # consumer of the vulnerable quick-xml 0.39 is wayland-scanner, whose newest
+    # release (0.31.10) still requires quick-xml "^0.39" and will not accept
+    # 0.41. That chain (wayland-scanner -> wayland-protocols -> ashpd -> rfd ->
+    # tauri-plugin-dialog) is an optional, cfg(linux/BSD)-gated build-time code
+    # generator that parses trusted local Wayland protocol XML; it never compiles
+    # on the primary macOS target and processes no attacker-controlled input.
+    # Revisit when wayland-scanner bumps to quick-xml >=0.41.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]


### PR DESCRIPTION
Closes #32.

## Summary

`cargo audit` now exits 0. Of the six advisories in #32, four were resolved by intervening dependency updates already in the lockfile, and the two remaining (unfixable) ones are acknowledged in `.cargo/audit.toml` with rationale.

## Already resolved (no longer reported)

| Advisory | Crate | Was | Now | Fix needed |
|---|---|---|---|---|
| RUSTSEC-2026-0185 | quinn-proto | 0.11.14 | **0.11.16** | >=0.11.15 |
| RUSTSEC-2026-0204 | crossbeam-epoch | 0.9.18 | **0.9.20** | >=0.9.20 |
| RUSTSEC-2026-0194/0195 (tauri chains) | quick-xml | 0.37/0.38 | **0.41.0** | >=0.41.0 |

## Acknowledged with rationale

`RUSTSEC-2026-0194` / `RUSTSEC-2026-0195` still apply to **quick-xml 0.39.4**, which now enters the tree through only one path:

\`\`\`
quick-xml 0.39.4 -> wayland-scanner 0.31.10 -> wayland-protocols -> ashpd -> rfd -> tauri-plugin-dialog
\`\`\`

There is **no fix path**: wayland-scanner's newest release (0.31.10) still requires \`quick-xml "^0.39"\` and will not accept 0.41. The chain is:

- **optional and platform-gated** - \`ashpd\` is \`cfg(any(target_os = "linux", "freebsd", ...))\` and optional, so this quick-xml never compiles on the primary macOS target (or Windows);
- **build-time codegen** - \`wayland-scanner\` parses trusted local Wayland protocol XML at build time, not attacker-controlled input.

Both are ignored in \`.cargo/audit.toml\` with a comment, matching the existing rsa (RUSTSEC-2023-0071) precedent. Revisit when wayland-scanner bumps to quick-xml >=0.41.

## Notes

- No dependency change was required, so no lockfile regeneration applies (the four fixes were already present from prior updates).
- The remaining Dependabot alerts on the default branch are the separately-triaged, intentionally-deferred glib/rand/lru/elliptic set - out of scope for #32.

## Verification

\`\`\`
cargo audit   # exits 0; before this change it reported "2 vulnerabilities found"
\`\`\`