### PR TITLE
style: format tree with rustfmt to fix Linting on main

### DIFF
--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -143,7 +143,9 @@ impl HelpSystem {
         message.push_str("      inferno models list\n\n");
         message.push_str("   2. Search HuggingFace for a model:\n");
         message.push_str("      inferno models search llama\n");
-        message.push_str("      inferno models search \"mistral instruct\" --task text-generation\n\n");
+        message.push_str(
+            "      inferno models search \"mistral instruct\" --task text-generation\n\n",
+        );
         message.push_str("   3. Install a model by HuggingFace repo ID or direct URL:\n");
         message.push_str("      inferno models install TheBloke/Llama-2-7B-GGUF\n");
         message.push_str("      inferno models install TheBloke/Mistral-7B-Instruct-v0.2-GGUF\n\n");

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,6 @@
 use crate::{
-    backends::BackendConfig, cache::CacheConfig,
-    deployment::DeploymentConfig, distributed::DistributedConfig,
-    logging_audit::LoggingAuditConfig,
+    backends::BackendConfig, cache::CacheConfig, deployment::DeploymentConfig,
+    distributed::DistributedConfig, logging_audit::LoggingAuditConfig,
     model_versioning::ModelVersioningConfig, monitoring::MonitoringConfig,
     observability::ObservabilityConfig, response_cache::ResponseCacheConfig,
 };


### PR DESCRIPTION
## Summary

A clean \`main\` currently fails \`cargo fmt --all -- --check\`:

- \`src/cli/help.rs:143\` - a long \`push_str\` line (introduced by #67)
- \`src/config.rs:1\` - a \`use\`-block import grouping (introduced by #64)

Both were merged unformatted. The **Linting** CI job runs \`cargo fmt --all -- --check\` over the whole tree, so this fails on main **and on every open code PR** branched from it (currently #68 and #69), and it's why main's own CI run is red.

## Change

\`cargo fmt --all\`. Two files, pure formatting - a wrapped \`push_str\` argument and a re-flowed import list. No behavior change.

## Verification

\`\`\`
cargo fmt --all -- --check   # clean after this change; failed on two files before
\`\`\`

Once merged, #68 and #69 should be rebased on main to pick this up (their Linting failures are this same pre-existing breakage; #68 additionally has one fmt nit of its own to fix on its branch).