### PR TITLE
fix(docs): deploy generated site content to GitHub Pages

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -242,16 +242,15 @@ jobs:
         convert_help_to_md('generated_docs/cli_help.txt', 'docs/src/api-reference/cli.md', 'CLI Reference')
         EOFILE
 
+        # Generate the changelog into the book source BEFORE building so it is
+        # actually rendered into the HTML. Previously this ran in a separate step
+        # AFTER `mdbook build`, so the changelog page shipped as an empty stub.
+        cargo install git-cliff --locked
+        git-cliff --config .github/cliff.toml --output docs/src/appendices/changelog.md \
+          || echo "::warning::changelog generation failed; shipping empty stub"
+
         # Build the book
         cd docs && mdbook build
-
-    - name: Generate changelog
-      run: |
-        # Install git-cliff if not already present
-        cargo install git-cliff --locked
-
-        # Generate changelog
-        git-cliff --config .github/cliff.toml --output docs/src/appendices/changelog.md
 
     - name: Validate documentation
       run: |
@@ -293,7 +292,7 @@ jobs:
     name: Deploy Documentation
     runs-on: ubuntu-latest
     needs: build-docs
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     timeout-minutes: 10
 
     permissions:
@@ -310,7 +309,12 @@ jobs:
       uses: actions/download-artifact@v5
       with:
         name: documentation-${{ github.sha }}
-        path: docs
+        # The build job uploads paths rooted at the workspace (docs/book,
+        # docs/api, generated_docs), so the artifact restores those trees under
+        # this directory as artifacts/docs/… . Downloading into `docs` nested it
+        # to docs/docs/… and every copy below silently failed (green build, empty
+        # site). Restore into a dedicated dir and copy from the real location.
+        path: artifacts
 
     - name: Setup Pages
       uses: actions/configure-pages@v5
@@ -319,18 +323,30 @@ jobs:
 
     - name: Prepare pages content
       run: |
-        mkdir -p pages
+        set -euo pipefail
+        rm -rf pages
+        mkdir -p pages/guide pages/api
 
-        # Copy user guide
-        cp -r docs/book/* pages/ || mkdir -p pages
+        # mdBook user guide -> /guide, rustdoc -> /api. Fail loudly if the guide
+        # is absent: the whole point of this site is the generated content, and a
+        # silent empty deploy is exactly the failure this workflow used to hide.
+        if [ -d artifacts/docs/book ] && [ -n "$(ls -A artifacts/docs/book 2>/dev/null)" ]; then
+          cp -r artifacts/docs/book/. pages/guide/
+        else
+          echo "::error::mdBook user guide missing from artifact (artifacts/docs/book empty)"
+          exit 1
+        fi
 
-        # Copy API docs to /api subdirectory
-        mkdir -p pages/api
-        cp -r docs/api/* pages/api/ || true
+        if [ -d artifacts/docs/api ] && [ -n "$(ls -A artifacts/docs/api 2>/dev/null)" ]; then
+          cp -r artifacts/docs/api/. pages/api/
+        else
+          echo "::warning::rustdoc API docs missing from artifact (artifacts/docs/api empty)"
+        fi
 
-        # Create index.html if it doesn't exist
-        if [ ! -f "pages/index.html" ]; then
-          cat > pages/index.html << 'EOF'
+        # Landing hub, regenerated every deploy so its links stay correct. mdBook
+        # renders its entry point as guide/index.html (not book.html), which the
+        # old hard-coded ./book.html link got wrong.
+        cat > pages/index.html << 'EOF'
         <!DOCTYPE html>
         <html lang="en">
         <head>
@@ -347,7 +363,7 @@ jobs:
         <body>
             <h1>Inferno Documentation</h1>
             <div class="nav">
-                <a href="./book.html">User Guide</a>
+                <a href="./guide/index.html">User Guide</a>
                 <a href="./api/inferno/index.html">API Documentation</a>
                 <a href="https://github.com/ringo380/inferno">GitHub Repository</a>
             </div>
@@ -360,7 +376,6 @@ jobs:
         </body>
         </html>
         EOF
-        fi
 
     - name: Upload to GitHub Pages
       uses: actions/upload-pages-artifact@v4


### PR DESCRIPTION
## Problem

The public docs site (https://ringo380.github.io/inferno/) serves only a placeholder landing page, and both of its content links are dead 404s:

| URL | Status |
|-----|--------|
| `/` | 200 (fallback landing page) |
| `/book.html` (User Guide link) | 404 |
| `/api/inferno/index.html` (API Documentation link) | 404 |

The `documentation.yml` pipeline reports green on every run while shipping an empty site.

## Root cause

The build job uploads the artifact rooted at the workspace (`docs/book`, `docs/api`, `generated_docs`). The deploy job downloaded it into `path: docs`, nesting it to `docs/docs/…`. Every `cp -r docs/book/*` in *Prepare pages content* then failed with `cannot stat 'docs/book/*'` and was swallowed by `|| true`, so only the fallback `index.html` was ever uploaded to Pages. Confirmed in the last deploy log (run 29667564351):

```
cp: cannot stat 'docs/book/*': No such file or directory
cp: cannot stat 'docs/api/*': No such file or directory
./index.html
```

## Fix

- Download the artifact into a dedicated dir and copy from the real location (`artifacts/docs/book`, `artifacts/docs/api`).
- Serve the mdBook guide under `/guide` and rustdoc under `/api`; regenerate the landing hub every deploy and point the User Guide link at `guide/index.html` (mdBook renders no `book.html` - the old link 404'd).
- **Fail the deploy if the guide is missing**, so an empty site can no longer pass as green.
- Generate the changelog *before* `mdbook build` so it actually renders (it ran after the build, shipping an empty stub).
- Allow the deploy job to run via `workflow_dispatch` on main for testing.

## Verification

- `actionlint` passes.
- Simulated the artifact nesting locally: the old `path: docs` reproduces `no matches found: docs/book/*` with an empty `pages/`; the new `path: artifacts` lands `pages/index.html`, `pages/guide/index.html`, and `pages/api/inferno/index.html` (both link targets resolve).
- Live Pages deploy to be confirmed after merge to main.